### PR TITLE
fix(scraper-tadb): escape apostrophes in names

### DIFF
--- a/metadata.musicvideos.theaudiodb.com/addon.xml
+++ b/metadata.musicvideos.theaudiodb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.musicvideos.theaudiodb.com"
        name="TheAudioDb.com for Music Videos"
-       version="1.2.6"
+       version="1.2.7"
        provider-name="XBMC Foundation">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.musicvideos.theaudiodb.com/changelog.txt
+++ b/metadata.musicvideos.theaudiodb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.2.7[/B]
+- Fixed: Allow for apostrophes in artist/title
+
 [B]1.2.1[/B]
 - Fixed: Allow for dashes in artist/title (v12.2+ required)
 

--- a/metadata.musicvideos.theaudiodb.com/tadb.xml
+++ b/metadata.musicvideos.theaudiodb.com/tadb.xml
@@ -7,6 +7,9 @@
 	</NfoUrl>
 	<CreateSearchUrl dest="3">
 		<RegExp input="$$5" output="\1" dest="3">
+			<RegExp input="$$1" output="\1\\&apos;\2" dest="1">
+				<expression repeat="yes">((?:[^%]*(?:%20))*[^%]*)(?:%27)((?:[^%]*(?:%20))*[^%]*)</expression>
+			</RegExp>
 			<RegExp input="$$1" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=\1&amp;amp;t=\2&lt;/url&gt;" dest="6">
 				<expression trim="1,2">(.+)%20(?:%20|-)%20(.+)</expression>
 			</RegExp>


### PR DESCRIPTION
Escape apostrophes in filenames with a backslash like so, (\'), so that they can be scraped by theaudiodb music video scraper.

See [this issue in the forum](http://forum.kodi.tv/showthread.php?pid=1809327#pid1809327)

>I used this addon recently for the first time, and it had trouble finding matches for artists/titles that contained an apostrophe ( ' ).
I found that this could be fixed by replacing the apostrophe ( ' ) with backslash+apostrophe ( \' ) when adding manually the files to the library from within XMBC.
e.g.: The Weather Girls - It's Raining Men ---> The Weather Girls - It\'s Raining Men
Actually, the search field of TheAudioDB.com is doing this substitution. Just try searching for something and then in the results page see the text chain after "Search Results for...".

This solution simply finds %27 characters in the filename and replaces them with `\'`, encoded as `\\&apos;`. This should work whether there are one or more apostrophe. While it has not been tested on a real world file with more than one apostrophe, I was able to use the debug log to show this. If anyone knows of a song title with more than one apostrophe leases let me know and I can confirm this with it.