### PR TITLE
Fixed runtime beeing zero in some cases

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="1.8.1"
+       version="1.8.2"
        provider-name="XBMC Foundation">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.8.2[/B]
+- Fixed: Runtime being zero in some cases
+
 [B]1.8.1[/B]
 - removed unsupported languages
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -83,7 +83,7 @@
 				<RegExp input="$$5" output="\1" dest="11">
 					<expression clear="yes">&lt;IMDB_ID&gt;([^&lt;]+)&lt;/IMDB_ID&gt;</expression>
 				</RegExp>
-				<RegExp input="$$11">
+				<RegExp input="$$11" output="\1" dest="13">
 					<RegExp conditional="fallback" input="$$5" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="13+">
 						<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
 					</RegExp>
@@ -329,7 +329,7 @@
 				<RegExp input="$$8" output="\1" dest="11">
 					<expression clear="yes">&lt;IMDB_ID&gt;([^&lt;]+)&lt;/IMDB_ID&gt;</expression>
 				</RegExp>
-				<RegExp input="$$11">
+				<RegExp input="$$11" output="\1" dest="13">
 					<RegExp conditional="fallback" input="$$8" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="13+">
 						<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
 					</RegExp>


### PR DESCRIPTION
Runtime could be zero, as it could not be found, when the rating/vote match hits.

In that case it's overwriting buffer 1 before the runtime has a chance of getting extracted.
```<RegExp input="$$11">``` seems to fall back to buffer 1 as it's not set, so it's overwritten

So I moved the processing of the runtime before that code for now.