### PR TITLE
Cleanup of the Settings dialog for metadata.universal

### DIFF
--- a/metadata.universal/resources/language/English/strings.po
+++ b/metadata.universal/resources/language/English/strings.po
@@ -43,7 +43,7 @@ msgstr ""
 #empty string with id 30007
 
 msgctxt "#30008"
-msgid "     Preferred Title Language from"
+msgid "Preferred Title Language from"
 msgstr ""
 
 msgctxt "#30009"
@@ -79,7 +79,7 @@ msgstr ""
 #empty strings from id 30017 to 30019
 
 msgctxt "#30020"
-msgid "     Preferred Plot Language"
+msgid "Preferred Plot Language"
 msgstr ""
 
 msgctxt "#30021"
@@ -107,7 +107,7 @@ msgid "Genres Sources"
 msgstr ""
 
 msgctxt "#30027"
-msgid "     Preferred Title Language"
+msgid "Preferred Title Language"
 msgstr ""
 
 msgctxt "#30028"
@@ -131,11 +131,11 @@ msgid "Get Certification From"
 msgstr ""
 
 msgctxt "#30033"
-msgid "     Preferred Certification Country"
+msgid "Preferred Certification Country"
 msgstr ""
 
 msgctxt "#30034"
-msgid "     Preferred Thumb Language"
+msgid "Preferred Thumb Language"
 msgstr ""
 
 msgctxt "#30035"
@@ -159,11 +159,11 @@ msgid "Enable trailers from trakt.tv"
 msgstr ""
 
 msgctxt "#30040"
-msgid "     Genre Language"
+msgid "Genre Language"
 msgstr ""
 
 msgctxt "#30041"
-msgid "     Preferred Trailer Language"
+msgid "Preferred Trailer Language"
 msgstr ""
 
 msgctxt "#30042"
@@ -171,7 +171,7 @@ msgid "Get Tagline From"
 msgstr ""
 
 msgctxt "#30043"
-msgid "     Preferred Tagline Language"
+msgid "Preferred Tagline Language"
 msgstr ""
 
 msgctxt "#30044"
@@ -183,7 +183,7 @@ msgid "Get Outline From"
 msgstr ""
 
 msgctxt "#30046"
-msgid "     Preferred Set (Collection) Name Language"
+msgid "Preferred Set (Collection) Name Language"
 msgstr ""
 
 msgctxt "#30047"
@@ -203,13 +203,13 @@ msgstr ""
 #empty strings from id 30101 to 30109
 
 msgctxt "#30110"
-msgid "     Rating Generated Using"
+msgid "Rating Generated Using"
 msgstr ""
 
 #empty strings from id 30111 to 30114
 
 msgctxt "#30115"
-msgid "     Use the Score Aggregated from"
+msgid "Use the Score Aggregated from"
 msgstr ""
 
 #empty strings from id 30116 to 30199
@@ -245,11 +245,11 @@ msgid "Search Engine to Use"
 msgstr ""
 
 msgctxt "#30304"
-msgid "     Secondary Search Language (In Addition to en-us)"
+msgid "Secondary Search Language (In Addition to en-us)"
 msgstr ""
 
 msgctxt "#30305"
-msgid "     Include All Movie Categories"
+msgid "Include All Movie Categories"
 msgstr ""
 
 msgctxt "#30306"
@@ -261,7 +261,7 @@ msgid "Enabling All Movie Categories will greatly reduce the search accuracy !!!
 msgstr ""
 
 msgctxt "#30308"
-msgid "     Preferred Search Language"
+msgid "Preferred Search Language"
 msgstr ""
 
 #empty strings from id 30309 to 30399

--- a/metadata.universal/resources/settings.xml
+++ b/metadata.universal/resources/settings.xml
@@ -2,40 +2,40 @@
 <settings>
   <category label="128">
     <setting type="sep"/>
-      <setting label="30023" type="labelenum" values="IMDb|themoviedb.org" id="titlesource" default="IMDb"/>
-      <setting label="30008" type="select" values="Keep Original|USA / International|Argentina|Austria|Belgium|Brazil|Bulgaria|Canada|China|Colombia|Chile|Croatia|Czech Republic|Denmark|Finland|France|Germany|Greece|Hong Kong|Hungary|Iceland|India|Israel|Italy|Japan|Mexico|Netherlands|Norway|Pakistan|Poland|Portugal|Romania|Russia|Serbia|Singapore|Slovenia|Spain|Sweden|Switzerland|Thailand|Turkey|Uruguay|Venezuela" id="imdbakatitles" default="Keep Original" visible="eq(-1,0)"/>
-      <setting label="30027" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtitlelanguage" default="en" visible="eq(-2,1)"/>
+    <setting label="30023" type="labelenum" values="IMDb|themoviedb.org" id="titlesource" default="IMDb"/>
+    <setting label="30008" subsetting="true" type="select" values="Keep Original|USA / International|Argentina|Austria|Belgium|Brazil|Bulgaria|Canada|China|Colombia|Chile|Croatia|Czech Republic|Denmark|Finland|France|Germany|Greece|Hong Kong|Hungary|Iceland|India|Israel|Italy|Japan|Mexico|Netherlands|Norway|Pakistan|Poland|Portugal|Romania|Russia|Serbia|Singapore|Slovenia|Spain|Sweden|Switzerland|Thailand|Turkey|Uruguay|Venezuela" id="imdbakatitles" default="Keep Original" visible="eq(-1,0)"/>
+    <setting label="30027" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtitlelanguage" default="en" visible="eq(-2,1)"/>
     <setting type="sep"/>
-      <setting label="30022" type="labelenum" values="IMDb|themoviedb.org|trakt.tv" id="genressource" default="IMDb"/>
-      <setting label="30040" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbgenreslanguage" default="en" visible="eq(-1,1)"/>
+    <setting label="30022" type="labelenum" values="IMDb|themoviedb.org|trakt.tv" id="genressource" default="IMDb"/>
+    <setting label="30040" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbgenreslanguage" default="en" visible="eq(-1,1)"/>
     <setting type="sep"/>
-      <setting label="30013" type="bool" id="tmdbset" default="true"/>
-      <setting label="30046" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbsetlanguage" default="en" enable="!eq(-1,false)"/>
+    <setting label="30013" type="bool" id="tmdbset" default="true"/>
+    <setting label="30046" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbsetlanguage" default="en" enable="eq(-1,true)"/>
     <setting type="sep"/>
-      <setting label="30048" type="labelenum" values="themoviedb.org|None" id="tmdbtags" default="None"/>
+    <setting label="30048" type="labelenum" values="themoviedb.org|None" id="tmdbtags" default="None"/>
     <setting type="sep"/>
   </category>
 
   <category label="30400">
     <setting type="lsep" label="30401"/>
-      <setting type="sep"/>
-      <setting label="30014" type="labelenum" values="IMDb|themoviedb.org|Rotten Tomatoes|trakt.tv|OFDb.de|port.hu|Rotten Tomatoes / Critics' Consensus|IMDb Outline" id="plotsource" default="IMDb"/>
-      <setting label="30020" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbplotlanguage" default="en" visible="eq(-1,1)"/>
     <setting type="sep"/>
-      <setting label="30042" type="labelenum" values="IMDb|themoviedb.org|None" id="taglinesource" default="IMDb"/>
-      <setting label="30043" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtaglinelanguage" default="en" visible="eq(-1,1)"/>
+    <setting label="30014" type="labelenum" values="IMDb|themoviedb.org|Rotten Tomatoes|trakt.tv|OFDb.de|port.hu|Rotten Tomatoes / Critics' Consensus|IMDb Outline" id="plotsource" default="IMDb"/>
+    <setting label="30020" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbplotlanguage" default="en" visible="eq(-1,1)"/>
     <setting type="sep"/>
-      <setting label="30045" type="labelenum" values="IMDb|Rotten Tomatoes / Critics' Consensus|None" id="outlinesource" default="IMDb"/>
+    <setting label="30042" type="labelenum" values="IMDb|themoviedb.org|None" id="taglinesource" default="IMDb"/>
+    <setting label="30043" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtaglinelanguage" default="en" visible="eq(-1,1)"/>
+    <setting type="sep"/>
+    <setting label="30045" type="labelenum" values="IMDb|Rotten Tomatoes / Critics' Consensus|None" id="outlinesource" default="IMDb"/>
     <setting type="sep"/>
   </category>
 
   <category label="30200">
     <setting type="sep"/>
-      <setting label="30015" type="labelenum" values="IMDb|IMDbFull|themoviedb.org" id="creditssource" default="IMDb"/>
+    <setting label="30015" type="labelenum" values="IMDb|IMDbFull|themoviedb.org" id="creditssource" default="IMDb"/>
     <setting type="sep"/>
-      <setting label="30201" type="labelenum" values="IMDb|themoviedb.org" id="studiosource" default="IMDb"/>
+    <setting label="30201" type="labelenum" values="IMDb|themoviedb.org" id="studiosource" default="IMDb"/>
     <setting type="sep"/>
-      <setting label="30202" type="labelenum" values="IMDb|themoviedb.org" id="countrysource" default="IMDb"/>
+    <setting label="30202" type="labelenum" values="IMDb|themoviedb.org" id="countrysource" default="IMDb"/>
     <setting type="sep"/>
   </category>
 
@@ -45,7 +45,7 @@
     <setting label="30502" type="bool" id="fanarttvposter" default="false"/>
     <setting type="sep"/>
     <setting label="30002" type="bool" id="tmdbthumbs" default="true"/>
-    <setting label="30034" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbthumblanguage" default="en" enable="!eq(-1,false)"/>
+    <setting label="30034" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbthumblanguage" default="en" enable="eq(-1,true)"/>
     <setting type="sep"/>
     <setting label="30037" type="bool" id="trakttvposter" default="false"/>
     <setting type="sep"/>
@@ -74,7 +74,7 @@
     <setting label="30006" type="select" values="No|480p|720p|1080p" id="TrailerQ" default="No"/>
     <setting type="sep"/>
     <setting label="30009" type="bool" id="tmdbtrailer" default="true"/>
-    <setting label="30041" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtrailerlanguage" default="en" enable="!eq(-1,false)"/>
+    <setting label="30041" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbtrailerlanguage" default="en" enable="eq(-1,true)"/>
     <setting type="sep"/>
     <setting label="30039" type="bool" id="trakttvtrailer" default="false"/>
     <setting type="sep"/>
@@ -84,32 +84,29 @@
     <setting type="lsep" label="30030"/>
     <setting type="sep"/>
     <setting label="30021" type="labelenum" values="IMDb|Rotten Tomatoes|MetaCritic|themoviedb.org|trakt.tv" id="mratingsource" default="IMDb"/>
-      <setting label="30110" type="labelenum" values="TomatoMeter|Average Rating" id="tomato" default="TomatoMeter" visible="eq(-2,1)"/>
-      <setting label="30115" type="labelenum" values="All Critics|Top Critics" id="allcritics" default="All Critics" visible="eq(-3,1)"/>
+    <setting label="30110" subsetting="true" type="labelenum" values="TomatoMeter|Average Rating" id="tomato" default="TomatoMeter" visible="eq(-2,1)"/>
+    <setting label="30115" subsetting="true" type="labelenum" values="All Critics|Top Critics" id="allcritics" default="All Critics" visible="eq(-3,1)"/>
     <setting type="sep"/>
     <setting label="30044" type="bool" id="imdbtop250" default="true"/>
     <setting type="sep"/>
     <setting type="lsep" label="30031"/>
     <setting label="30032" type="labelenum" values="IMDb|themoviedb.org" id="certificationssource" default="IMDb"/>
-      <setting label="30033" type="select" values="Argentina|Australia|Austria|Belgium|Brazil|Bulgaria|Canada|China|Colombia|Chile|Croatia|Czech Republic|Denmark|Finland|France|Germany|Greece|Hong Kong|Hungary|Iceland|India|Israel|Italy|Japan|Mexico|Netherlands|Norway|Pakistan|Poland|Portugal|Romania|Russia|Serbia|Singapore|Slovenia|Spain|Sweden|Switzerland|Thailand|Turkey|UK|Uruguay|USA|Venezuela" id="imdbcertcountry" default="USA" visible="eq(-1,0)"/>
-      <setting label="30033" type="select" values="au|bg|br|cs|da|de|el|es|fi|fr|gb|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|us|zh" id="tmdbcertcountry" default="us" visible="eq(-2,1)"/>/>
-      <setting type="sep"/>
+    <setting label="30033" subsetting="true" type="select" values="Argentina|Australia|Austria|Belgium|Brazil|Bulgaria|Canada|China|Colombia|Chile|Croatia|Czech Republic|Denmark|Finland|France|Germany|Greece|Hong Kong|Hungary|Iceland|India|Israel|Italy|Japan|Mexico|Netherlands|Norway|Pakistan|Poland|Portugal|Romania|Russia|Serbia|Singapore|Slovenia|Spain|Sweden|Switzerland|Thailand|Turkey|UK|Uruguay|USA|Venezuela" id="imdbcertcountry" default="USA" visible="eq(-1,0)"/>
+    <setting label="30033" subsetting="true" type="select" values="au|bg|br|cs|da|de|el|es|fi|fr|gb|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|us|zh" id="tmdbcertcountry" default="us" visible="eq(-2,1)"/>/>
+    <setting type="sep"/>
     <setting label="30035" type="text" id="certprefix" default="Rated "/>
     <setting type="sep"/>
   </category>
 
   <category label="30300">
-    <setting type="lsep" label="30303"/>
     <setting type="sep"/>
-    <setting label="30301" type="bool" id="tmdbsearch" default="false" enable="!eq(2,true)"/>
-    <setting label="30308" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbsearchlanguage" default="en" visible="eq(-1,true)"/>
+    <setting label="30303" type="labelenum" values="IMDb|themoviedb.org" id="searchservice" default="IMDb"/>
+    <setting label="30308" subsetting="true" type="select" values="bg|cs|da|de|el|en|es|fi|fr|he|hr|hu|it|ja|ko|nl|no|pl|pt|ru|sl|sv|tr|zh" id="tmdbsearchlanguage" default="en" visible="eq(-1,1)"/>
+    <setting label="30304" subsetting="true" type="select" values="bg-bg|cs-cz|el-gr|es-ar|da-dk|de-at|de-de|fi-fi|fr-fr|hr-hr|he-il|hu-hu|it-it|ja-jp|nb-no|nl-nl|pl-pl|pt-pt|ro-ro|ru-ru|se-se|sl-si|sr-rs|th-th|tr-tr|None" id="imdbsearchlanguage" default="None" visible="eq(-2,0)"/>
+    <setting label="30305" subsetting="true" type="bool" id="fullimdbsearch" default="false" visible="eq(-3,0)"/>
     <setting type="sep"/>
-    <setting label="30302" type="bool" id="imdbsearch" default="true" enable="!eq(-2,true)"/>
-    <setting label="30304" type="select" values="bg-bg|cs-cz|el-gr|es-ar|da-dk|de-at|de-de|fi-fi|fr-fr|hr-hr|he-il|hu-hu|it-it|ja-jp|nb-no|nl-nl|pl-pl|pt-pt|ro-ro|ru-ru|se-se|sl-si|sr-rs|th-th|tr-tr|None" id="imdbsearchlanguage" default="None" visible="!eq(-1,false)"/>
-    <setting label="30305" type="bool" id="fullimdbsearch" default="false" visible="!eq(-2,false)"/>
-    <setting type="sep"/>
-    <setting type="lsep" label="30306" visible="!eq(-2,false)"/>
-    <setting type="lsep" label="30307" visible="!eq(-3,false)"/>
+    <setting type="lsep" label="30306" visible="eq(-2,true)"/>
+    <setting type="lsep" label="30307" visible="eq(-3,true)"/>
   </category>
 
 </settings>

--- a/metadata.universal/universal.xml
+++ b/metadata.universal/universal.xml
@@ -1,79 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2014-07-24">
 	<NfoUrl dest="3">
-		<RegExp conditional="tmdbsearch" input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="3">
-			<expression clear="yes" noclean="1">(themoviedb.org/movie/)([0-9]*)</expression>
+		<RegExp input="$INFO[searchservice]" output="$$16" dest="3">
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="16">
+				<expression clear="yes" noclean="1">(themoviedb.org/movie/)([0-9]*)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
+				<expression>imdb....?/title/tt([0-9]+)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
+				<expression>imdb....?/Title\?t{0,2}([0-9]+)</expression>
+			</RegExp>
+			<expression>themoviedb.org</expression>
 		</RegExp>
-		<RegExp conditional="tmdbsearch" input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
-			<expression>imdb....?/title/tt([0-9]+)</expression>
-		</RegExp>
-		<RegExp conditional="tmdbsearch" input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
-			<expression>imdb....?/Title\?t{0,2}([0-9]+)</expression>
-		</RegExp>
-		<RegExp conditional="imdbsearch" input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="3">
-			<expression clear="yes" noclean="1">imdb....?/Title\?([0-9]*)</expression>
-		</RegExp>
-		<RegExp conditional="imdbsearch" input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="3+">
-			<expression noclean="1">imdb....?/title/tt([0-9]*)</expression>
+
+		<RegExp input="$INFO[searchservice]" output="$$16" dest="3">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16">
+				<expression clear="yes" noclean="1">imdb....?/Title\?([0-9]*)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16+">
+				<expression noclean="1">imdb....?/title/tt([0-9]*)</expression>
+			</RegExp>
+			<expression>IMDb</expression>
 		</RegExp>
 	</NfoUrl>
 	<CreateSearchUrl dest="3" clearbuffers="no">
-		<RegExp conditional="tmdbsearch" input="$$1" output="&lt;url&gt;http://api.tmdb.org/3/search/movie?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;query=\1&amp;amp;year=$$4&lt;/url&gt;" dest="3">
-			<RegExp input="$$2" output="\1" dest="4">
-				<expression clear="yes">(.+)</expression>
+		<RegExp input="$INFO[searchservice]" output="$$17" dest="3">
+			<RegExp input="$$1" output="&lt;url&gt;http://api.tmdb.org/3/search/movie?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;query=\1&amp;amp;year=$$4&lt;/url&gt;" dest="17">
+				<RegExp input="$$2" output="\1" dest="4">
+					<expression clear="yes">(.+)</expression>
+				</RegExp>
+				<expression noclean="1" />
 			</RegExp>
-			<expression noclean="1" />
+			<expression>themoviedb.org</expression>
 		</RegExp>
-		<RegExp conditional="imdbsearch" input="$$1" output="&lt;url&gt;http://akas.imdb.com/find?q=\1&amp;s=tt|accept-language=en-us&lt;/url&gt;" dest="3">
-			<RegExp input="$$2" output="%20(\1)" dest="4">
-				<expression clear="yes">(.+)</expression>
+		<RegExp input="$INFO[searchservice]" output="$$17" dest="3">
+			<RegExp input="$$1" output="&lt;url&gt;http://akas.imdb.com/find?q=\1&amp;s=tt|accept-language=en-us&lt;/url&gt;" dest="17">
+				<RegExp input="$$2" output="%20(\1)" dest="4">
+					<expression clear="yes">(.+)</expression>
+				</RegExp>
+				<RegExp input="$$1" output="\1" dest="9">
+					<expression clear="yes" noclean="1"/>
+				</RegExp>
+				<expression noclean="1"/>
 			</RegExp>
-			<RegExp input="$$1" output="\1" dest="9">
-			<expression clear="yes" noclean="1"/>
-			</RegExp>
-			<expression noclean="1"/>
+			<expression>IMDb</expression>
 		</RegExp>
 	</CreateSearchUrl>
 	<GetSearchResults dest="8">
-		<RegExp conditional="tmdbsearch" input="$$5" output="&lt;results&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5">
-				<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;title&quot;:&quot;([^&quot;]*)</expression>
+		<RegExp input="$INFO[searchservice]" output="$$17" dest="8">
+			<RegExp input="$$5" output="&lt;results&gt;\1&lt;/results&gt;" dest="17">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5">
+					<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;title&quot;:&quot;([^&quot;]*)</expression>
+				</RegExp>
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+					<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:&quot;([0-9]+)-</expression>
+				</RegExp>
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+					<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:null</expression>
+				</RegExp>
+				<expression noclean="1" />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:&quot;([0-9]+)-</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes">&quot;id&quot;:([0-9]*),&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;overview&quot;:&quot;.*?&quot;,&quot;release_date&quot;:null</expression>
-			</RegExp>
-			<expression noclean="1" />
+			<expression>themoviedb.org</expression>
 		</RegExp>
-		<RegExp conditional="imdbsearch" input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;iso-8859-1&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="\1" dest="7">
-				<expression clear="yes">/title/([t0-9]*)/(combined|faq|releaseinfo|vote)</expression>
+		
+		<RegExp input="$INFO[searchservice]" output="$$17" dest="8">
+			<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;iso-8859-1&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="17">
+				<RegExp input="$$1" output="\1" dest="7">
+					<expression clear="yes">/title/([t0-9]*)/(combined|faq|releaseinfo|vote)</expression>
+				</RegExp>
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5">
+					<expression clear="yes" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?([^&quot;]*?)(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\)</expression>
+				</RegExp>
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+					<expression fixchars="2" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?[^&quot;]*?(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\).*?Also Known As:&lt;/h4&gt;([^\n]*)</expression>
+				</RegExp>
+				<RegExp input="$$1" output="\1" dest="4">
+					<expression noclean="1">&lt;table class=&quot;findList&quot;(.*?)&lt;/div</expression>
+				</RegExp>
+				<RegExp conditional="fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s|\(Short\)\s|\(TV\sMini-Series\)\s|\(TV\sSeries\)\s|\(TV\sShort\)\s|\(Short\)\s|\(Short\)\s)?&lt;</expression>
+				</RegExp>
+				<RegExp conditional="!fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s)?&lt;</expression>
+				</RegExp>
+				<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s&lt;br/&gt;aka\s&lt;i&gt;&quot;([^&quot;]*)</expression>
+				</RegExp>
+				<RegExp input="$INFO[imdbsearchlanguage]" output="&lt;url function=&quot;GetAKASearchResults&quot;&gt;http://akas.imdb.com/find?q=$$9&amp;s=tt|accept-language=$INFO[imdbsearchlanguage]&lt;/url&gt;" dest="5+">
+					<expression>^(?:bg-bg|cs-cz|el-gr|es-ar|da-dk|de-at|de-de|fi-fi|fr-fr|hr-hr|he-il|hu-hu|it-it|ja-jp|nb-no|nl-nl|pl-pl|pt-pt|ro-ro|ru-ru|se-se|sl-si|sr-rs|th-th|tr-tr)$</expression>
+				</RegExp>
+				<expression clear="yes" noclean="1"/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5">
-				<expression clear="yes" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?([^&quot;]*?)(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\)</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression fixchars="2" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?[^&quot;]*?(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\).*?Also Known As:&lt;/h4&gt;([^\n]*)</expression>
-			</RegExp>
-			<RegExp input="$$1" output="\1" dest="4">
-				<expression noclean="1">&lt;table class=&quot;findList&quot;(.*?)&lt;/div</expression>
-			</RegExp>
-			<RegExp conditional="fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s|\(Short\)\s|\(TV\sMini-Series\)\s|\(TV\sSeries\)\s|\(TV\sShort\)\s|\(Short\)\s|\(Short\)\s)?&lt;</expression>
-			</RegExp>
-			<RegExp conditional="!fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s)?&lt;</expression>
-			</RegExp>
-			<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s&lt;br/&gt;aka\s&lt;i&gt;&quot;([^&quot;]*)</expression>
-			</RegExp>
-			<RegExp input="$INFO[imdbsearchlanguage]" output="&lt;url function=&quot;GetAKASearchResults&quot;&gt;http://akas.imdb.com/find?q=$$9&amp;s=tt|accept-language=$INFO[imdbsearchlanguage]&lt;/url&gt;" dest="5+">
-				<expression>^(?:bg-bg|cs-cz|el-gr|es-ar|da-dk|de-at|de-de|fi-fi|fr-fr|hr-hr|he-il|hu-hu|it-it|ja-jp|nb-no|nl-nl|pl-pl|pt-pt|ro-ro|ru-ru|se-se|sl-si|sr-rs|th-th|tr-tr)$</expression>
-			</RegExp>
-			<expression clear="yes" noclean="1"/>
+			<expression>IMDb</expression>
 		</RegExp>
+		
+		
 	</GetSearchResults>
 	<GetAKASearchResults dest="8">
 		<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;iso-8859-1&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="8">
@@ -97,11 +119,17 @@
 			<RegExp input="$$1" output="\2" dest="20">
 				<expression>&lt;meta name=&quot;title&quot;\scontent=&quot;([^&quot;]*?)\s\([^\(]*?([0-9]{4})(?:–\s)?\)</expression>
 			</RegExp>
-			<RegExp conditional="tmdbsearch" input="$$1" output="\1" dest="2">
-				<expression noclean="1">&quot;id&quot;:([0-9]*),&quot;imdb_id</expression>
+			<RegExp input="$INFO[searchservice]" output="$$17" dest="2">
+				<RegExp input="$$1" output="\1" dest="17">
+					<expression noclean="1">&quot;id&quot;:([0-9]*),&quot;imdb_id</expression>
+				</RegExp>
+				<expression>themoviedb.org</expression>
 			</RegExp>
-			<RegExp conditional="tmdbsearch" input="$$1" output="\1" dest="2">
-				<expression noclean="1">&quot;id&quot;:[0-9]*,&quot;imdb_id&quot;:&quot;([^&quot;]*)</expression>
+			<RegExp input="$INFO[searchservice]" output="$$17" dest="2">
+				<RegExp input="$$1" output="\1" dest="17">
+					<expression noclean="1">&quot;id&quot;:[0-9]*,&quot;imdb_id&quot;:&quot;([^&quot;]*)</expression>
+				</RegExp>
+				<expression>themoviedb.org</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="19">
 				<expression fixchars="1">&quot;original_title&quot;:&quot;([^&quot;]*)</expression>


### PR DESCRIPTION
In PR 10, i introduced a problem where TMDB and IMDB search services can be both selected. The fix to it is included here.

Before this PR can be merged:
1) two subsettings for Rotten Tomatoes as the rating source were not being shown. I fixed them too. I checked to make sure the function did have the capability to handle the choices. Is there a chance that they were hidden on purpose?
2) wouldn't it look better if the Search category, would contain a "labelenum" for selecting the service provider?