### PR TITLE
Improved regex to match when type="Album" is not at the same position

### DIFF
--- a/metadata.common.musicbrainz.org/addon.xml
+++ b/metadata.common.musicbrainz.org/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.musicbrainz.org"
        name="MusicBrainz Scraper Library"
-        version="2.0.3"
+        version="2.0.4"
        provider-name="XBMC Foundation">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.common.musicbrainz.org/musicbrainz.xml
+++ b/metadata.common.musicbrainz.org/musicbrainz.xml
@@ -10,8 +10,8 @@
 			<RegExp input="" output="" dest="2">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;album&gt;&lt;year&gt;\4&lt;/year&gt;&lt;title&gt;\2&lt;/title&gt;&lt;label&gt;\1&lt;/label&gt;&lt;/album&gt;" dest="2">
-				<expression repeat="yes" clear="yes" fixchars="1,2,3" noclean="1,2,3"> type="Album" id="([^"]*)"&gt;&lt;title&gt;([^&lt;]*)&lt;/title&gt;&lt;first-release-date(\s/)?&gt;(\d{4})?</expression>
+			<RegExp input="$$1" output="&lt;album&gt;&lt;year&gt;\5&lt;/year&gt;&lt;title&gt;\3&lt;/title&gt;&lt;label&gt;\1\2&lt;/label&gt;&lt;/album&gt;" dest="2">
+				<expression repeat="yes" clear="yes" fixchars="1,2,3" noclean="1,2,3">(?: id="([^"]*)")? type="Album"(?: id="([^"]*)")?&gt;&lt;title&gt;([^&lt;]*)&lt;/title&gt;&lt;first-release-date(\s/)?&gt;(\d{4})?</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
If you open http://musicbrainz.org/ws/2/release-group?artist=298909e4-ebcb-47b8-95e9-cc53b087fc65&limit=100&type=album for example.
The ```type="Album"``` is either before or after the ```id="XXXXXXXXXX"``` this PR takes this into account and will also grab the ones where ```type="Album"``` is behind the id-tag.

If you don't see it on the link, please refresh a few times.