### PR TITLE
[addons] Music video scraper: Changed the apostrophe character handli…

### DIFF
--- a/metadata.musicvideos.theaudiodb.com/tadb.xml
+++ b/metadata.musicvideos.theaudiodb.com/tadb.xml
@@ -7,8 +7,11 @@
 	</NfoUrl>
 	<CreateSearchUrl dest="3">
 		<RegExp input="$$5" output="\1" dest="3">
-			<RegExp input="$$1" output="\1\\&apos;\2" dest="1">
-				<expression repeat="yes">((?:[^%]*(?:%20))*[^%]*)(?:%27)((?:[^%]*(?:%20))*[^%]*)</expression>
+			<RegExp input="$$1" output="\1%2c\2" dest="1">
+				<expression repeat="yes" noclean="1,2">(.+),(.+)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="\1%27\2" dest="1">
+				<expression repeat="yes" noclean="1,2">(.+)&apos;(.+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=\1&amp;amp;t=\2&lt;/url&gt;" dest="6">
 				<expression trim="1,2">(.+)%20(?:%20|-)%20(.+)</expression>


### PR DESCRIPTION
…ng to allow for the sequence ', (apostrophe comma)

Changed the code from escaping the apostrophe character, to URL encode comma, and then URL encode apostrophe.

This way the addon can handle ' (apostrophe) and , (comma) next to each other.
