### PR TITLE
[metadata.common.themoviedb.org] 2.13.2 - Grab all studios.

### DIFF
--- a/metadata.common.themoviedb.org/addon.xml
+++ b/metadata.common.themoviedb.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.themoviedb.org"
        name="The Movie Database Scraper Library"
-       version="2.13.1"
+       version="2.13.2"
        provider-name="XBMC Foundation">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.common.themoviedb.org/tmdb.xml
+++ b/metadata.common.themoviedb.org/tmdb.xml
@@ -326,7 +326,7 @@
 				<expression clear="yes" noclean="1">&quot;production_companies&quot;:\[([^\]]*)</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;studio&gt;\1&lt;/studio&gt;" dest="2">
-				<expression trim="1" fixchars="1">&quot;name&quot;:&quot;([^&quot;]*)</expression>
+				<expression trim="1" fixchars="1" repeat="yes">&quot;name&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
Adds `repeat="yes"` to the studios regex.
@olympia I see you intentionally changed it to only get the first studio - is there a reason for this?
https://github.com/xbmc/repo-scrapers/commit/5f6dd09b5fa93701805fa77e4325f58168a0b280