### PR TITLE
Enable HTTPS for all supported scrapers

### DIFF
--- a/metadata.album.universal/resources/settings.xml
+++ b/metadata.album.universal/resources/settings.xml
@@ -19,6 +19,6 @@
   </category>
 
   <category label="30011">
-      <setting label="30012" type="text" id="mbsite" default="http://musicbrainz.org"/>
+      <setting label="30012" type="text" id="mbsite" default="https://musicbrainz.org"/>
   </category>
 </settings>

--- a/metadata.anidb.net/anidb.xml
+++ b/metadata.anidb.net/anidb.xml
@@ -8,7 +8,7 @@
   </NfoUrl>
   
   <CreateSearchUrl clearbuffers="no" dest="4">  
-    <RegExp conditional="Google" input="$$4" output="&lt;url gzip=&quot;yes&quot;&gt;http://www.google.com/search?q=site:anidb.net\1&amp;filter=0&lt;/url&gt;" dest="4">
+    <RegExp conditional="Google" input="$$4" output="&lt;url gzip=&quot;yes&quot;&gt;https://www.google.com/search?q=site:anidb.net\1&amp;filter=0&lt;/url&gt;" dest="4">
       <RegExp input="$$1" output="+\1" dest="4">
         <expression clear="yes" repeat="yes">(?i)(?:%[a-f0-9]{2})*([a-z0-9]+)?</expression>
       </RegExp>
@@ -29,10 +29,10 @@
     <RegExp input="$$4" output="&lt;results&gt;\1&lt;/results&gt;" dest="4">
       <RegExp conditional="Google" input="$$4" output="\1" dest="4">
         <RegExp conditional="Google" input="$$1" output="&lt;url function=&quot;GetSearchResultsExt&quot; gzip=&quot;yes&quot; cache=&quot;\1.xml&quot;&gt;http://api.anidb.net:9001/httpapi?request=anime&amp;client=xbmcscrap&amp;clientver=1&amp;protover=1&amp;aid=\1&lt;/url&gt;" dest="4">
-          <expression clear="yes" repeat="yes">(?i)&lt;a href=&quot;http://anidb\.net/perl-bin/animedb\.pl\?show=anime&amp;amp;aid=(\d+)&quot;</expression>
+          <expression clear="yes" repeat="yes">(?i)&lt;a href=&quot;https://anidb\.net/perl-bin/animedb\.pl\?show=anime&amp;amp;aid=(\d+)&quot;</expression>
         </RegExp>
         <RegExp conditional="Google" input="$$1" output="&lt;url function=&quot;GetSearchResultsExt&quot; gzip=&quot;yes&quot; cache=&quot;\1.xml&quot;&gt;http://api.anidb.net:9001/httpapi?request=anime&amp;client=xbmcscrap&amp;clientver=1&amp;protover=1&amp;aid=\1&lt;/url&gt;" dest="4+">
-          <expression repeat="yes">(?i)&lt;a href=&quot;http://anidb\.net/a(\d+)&quot;</expression>
+          <expression repeat="yes">(?i)&lt;a href=&quot;https://anidb\.net/a(\d+)&quot;</expression>
         </RegExp>
         <expression noclean="1"/>
       </RegExp> 
@@ -418,11 +418,11 @@
       <RegExp input="$$6" output="\1" dest="6">
         <expression noclean="1">(?:\*\s?)?(.*)</expression>
       </RegExp>
-      <RegExp input="$$6" output="\1 http://anidb.net/a666 []" dest="6">
+      <RegExp input="$$6" output="\1 https://anidb.net/a666 []" dest="6">
         <expression/>
       </RegExp>
       <RegExp input="$$6" output="\1\2" dest="6">
-        <expression repeat="yes" noclean="1,2">(?i)(.*?)http://anidb.net/[a-z]+[0-9]+\s\[([^]]*)]</expression>
+        <expression repeat="yes" noclean="1,2">(?i)(.*?)https://anidb.net/[a-z]+[0-9]+\s\[([^]]*)]</expression>
       </RegExp>
       <RegExp input="$$6" output="\1 [url=][/url]" dest="6">
         <expression/>
@@ -442,11 +442,11 @@
       <RegExp input="$$6" output="\1" dest="6">
         <expression repeat="yes" noclean="1">(?i)(.*?)(?:(\[)|(\()|\*)(?(2)[^]]|(?(3)[^)]|[^*]))*$$10(?(2)[^]]|(?(3)[^)]|[^*]))*(?(2)\]|(?(3)\)|\*))</expression>
       </RegExp>
-      <RegExp input="$$6" output="\1 [http://]" dest="6">
+      <RegExp input="$$6" output="\1 [https://]" dest="6">
         <expression/>
       </RegExp>
       <RegExp input="$$6" output="\1" dest="6">
-        <expression repeat="yes" noclean="1">(?i)(.*?)(?:(\[)|(\()|\*)\s*http://(?(2)[^]]|(?(3)[^)]|[^*]))*(?(2)\]|(?(3)\)|\*))</expression>
+        <expression repeat="yes" noclean="1">(?i)(.*?)(?:(\[)|(\()|\*)\s*https://(?(2)[^]]|(?(3)[^)]|[^*]))*(?(2)\]|(?(3)\)|\*))</expression>
       </RegExp>
       <RegExp input="$$6" output="\1 [animenewsnetwork]" dest="6">
         <expression/>
@@ -460,11 +460,11 @@
       <RegExp input="$$6" output="\1" dest="6">
         <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[^\r\n]*$$10[: ]*$$11[^\r\n]*</expression>
       </RegExp>
-      <RegExp input="$$6" output="\n\1\nfrom http://\n" dest="6">
+      <RegExp input="$$6" output="\n\1\nfrom https://\n" dest="6">
         <expression/>
       </RegExp>
       <RegExp input="$$6" output="\1" dest="6">
-        <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[^\r\n]*$$10[: ]*http://[^\r\n]*</expression>
+        <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[^\r\n]*$$10[: ]*https://[^\r\n]*</expression>
       </RegExp>
       <RegExp input="$$6" output="\n\1\nann summary\n" dest="6">
         <expression/>
@@ -472,11 +472,11 @@
       <RegExp input="$$6" output="\1" dest="6">
         <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[^\r\n]*$$11[ ]*(?:summary|decription)[^\r\n]*</expression>
       </RegExp>
-      <RegExp input="$$6" output="\n\1\nhttp://\n" dest="6">
+      <RegExp input="$$6" output="\n\1\nhttps://\n" dest="6">
         <expression/>
       </RegExp>
       <RegExp input="$$6" output="\1" dest="6">
-        <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[ ]*http://[^\r\n ]*</expression>
+        <expression repeat="yes" noclean="1">(?i)(.*?)\r?\n[ ]*https://[^\r\n ]*</expression>
       </RegExp>
       <RegExp input="$$6" output="\n\1\nanimenfo\n" dest="6">
         <expression/>
@@ -521,10 +521,10 @@
       <RegExp input="$$1" output="\1" dest="6">
         <expression clear="yes" noclean="1">(?i)&lt;characters&gt;(.*?)&lt;/characters&gt;</expression>
       </RegExp>
-      <RegExp input="$$6" output="&lt;actor&gt;&lt;name&gt;\3&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;thumb&gt;http://img7.anidb.net/pics/anime/\2&lt;/thumb&gt;&lt;/actor&gt;" dest="16">
+      <RegExp input="$$6" output="&lt;actor&gt;&lt;name&gt;\3&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;thumb&gt;https://img7.anidb.net/pics/anime/\2&lt;/thumb&gt;&lt;/actor&gt;" dest="16">
         <expression clear="yes" repeat="yes">(?i)&lt;character.*?type=&quot;main character in&quot;[^&gt;]*&gt;.*?&lt;name&gt;([^&lt;]*)&lt;/name&gt;.*?&lt;seiyuu[^&gt;]*picture=&quot;([^&quot;]*)&quot;[^&gt;]*&gt;([^&lt;]*)&lt;/seiyuu&gt;.*?&lt;/character&gt;</expression>
       </RegExp>
-      <RegExp conditional="!OnlyMainCast" input="$$6" output="&lt;actor&gt;&lt;name&gt;\3&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;thumb&gt;http://img7.anidb.net/pics/anime/\2&lt;/thumb&gt;&lt;/actor&gt;" dest="16+">
+      <RegExp conditional="!OnlyMainCast" input="$$6" output="&lt;actor&gt;&lt;name&gt;\3&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;thumb&gt;https://img7.anidb.net/pics/anime/\2&lt;/thumb&gt;&lt;/actor&gt;" dest="16+">
         <expression repeat="yes">(?i)&lt;character.*?type=&quot;secondary cast in&quot;[^&gt;]*&gt;.*?&lt;name&gt;([^&lt;]*)&lt;/name&gt;.*?&lt;seiyuu[^&gt;]*picture=&quot;([^&quot;]*)&quot;[^&gt;]*&gt;([^&lt;]*)&lt;/seiyuu&gt;.*?&lt;/character&gt;</expression>
       </RegExp>
       <RegExp input="$$17" output="\1" dest="16+">
@@ -640,7 +640,7 @@
       <RegExp input="" output="" dest="15">
         <expression clear="yes"/>
       </RegExp>
-      <RegExp conditional="Posters" input="$$1" output="&lt;thumb&gt;http://img7.anidb.net/pics/anime/\1&lt;/thumb&gt;" dest="15">
+      <RegExp conditional="Posters" input="$$1" output="&lt;thumb&gt;https://img7.anidb.net/pics/anime/\1&lt;/thumb&gt;" dest="15">
         <expression>(?i)&lt;picture&gt;([^&lt;]+)&lt;/picture&gt;</expression>
       </RegExp>
       <RegExp conditional="Posters" input="$$17" output="\1" dest="15+">
@@ -664,7 +664,7 @@
       <RegExp input="$$19" output="\1" dest="19">
         <expression clear="yes">(?i)tvdbid=&quot;([^&quot;]*)&quot;</expression>
       </RegExp>
-      <RegExp input="$$19" output="&lt;url function=&quot;GetFanartDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="6">
+      <RegExp input="$$19" output="&lt;url function=&quot;GetFanartDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="6">
         <expression>(\d+)</expression>
       </RegExp>
       <RegExp input="$$19" output="&lt;url function=&quot;GetFanartDataReturnAPI&quot; cache=&quot;$$20.xml&quot;&gt;&amp;&lt;/url&gt;" dest="6">
@@ -696,7 +696,7 @@
   -->
 
   <GetTVDBLookupAPI clearbuffers="no" dest="4">
-    <RegExp input="$$9" output="&lt;details&gt;&lt;url function=&quot;GetFanartAPI&quot; cache=&quot;tvdb-s$$20-\1.xml&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&lt;/url&gt;&lt;/details&gt;" dest="4">
+    <RegExp input="$$9" output="&lt;details&gt;&lt;url function=&quot;GetFanartAPI&quot; cache=&quot;tvdb-s$$20-\1.xml&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&lt;/url&gt;&lt;/details&gt;" dest="4">
       <RegExp input="$$1" output="\1" dest="5">
         <expression clear="yes" trim="1">(?i)&lt;title.*?type=&quot;main&quot;&gt;([^&lt;]+)&lt;/title&gt;</expression>
       </RegExp>
@@ -784,7 +784,7 @@
 
   <GetTVDBLookupLoopAPI clearbuffers="no" dest="4">
     <RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-      <RegExp input="$$8" output="&lt;url function=&quot;GetFanartAPI&quot; cache=&quot;tvdb-s$$20-\1.xml&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&lt;/url&gt;" dest="5">
+      <RegExp input="$$8" output="&lt;url function=&quot;GetFanartAPI&quot; cache=&quot;tvdb-s$$20-\1.xml&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&lt;/url&gt;" dest="5">
         <RegExp input="$$18" output="\1" dest="8">
           <expression clear="yes" noclean="1">(?i)&lt;title&gt;([^&lt;]+)&lt;/title&gt;</expression>
         </RegExp>
@@ -821,7 +821,7 @@
       <RegExp input="$$20" output="&lt;url function=&quot;GetTVDBLookupLoopAPI&quot; cache=&quot;\1.xml&quot;&gt;&amp;&lt;/url&gt;" dest="4">
         <expression clear="yes"/>
       </RegExp>
-      <RegExp input="$$1" output="&lt;url function=&quot;GetFanartDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="4">
+      <RegExp input="$$1" output="&lt;url function=&quot;GetFanartDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="4">
         <expression>(?i)&lt;seriesid&gt;(\d+)&lt;/seriesid&gt;</expression>
       </RegExp>
       <RegExp input="$$1" output="&lt;anime anidbid=&quot;$$20&quot; tvdbid=&quot;\1&quot; defaulttvdbseason=&quot;1&quot;&gt;&lt;name&gt;$$20&lt;/name&gt;&lt;/anime&gt;" dest="5">
@@ -863,28 +863,28 @@
       <RegExp input="$$1" output="\1" dest="5">
         <expression clear="yes" noclean="1">(?i)&lt;Banners&gt;(.*?)&lt;/Banners&gt;</expression>
       </RegExp>
-      <RegExp conditional="Fanarts" input="$$6" output="&lt;fanart url=&quot;http://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="16+">
+      <RegExp conditional="Fanarts" input="$$6" output="&lt;fanart url=&quot;https://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="16+">
         <RegExp input="$$5" output="&lt;thumb dim=&quot;\2&quot; colors=&quot;\3&quot; preview=&quot;_cache/\1&quot;&gt;\1&lt;/thumb&gt;" dest="6">
           <expression clear="yes" repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;fanart&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;([^&lt;]*)&lt;/BannerType2&gt;[^&lt;]*&lt;Colors&gt;([^&lt;]*)&lt;/Colors&gt;</expression>
         </RegExp>
         <expression noclean="1">(.+)</expression>
       </RegExp>
-      <RegExp conditional="Posters" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="15+">
+      <RegExp conditional="Posters" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="15+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
       </RegExp>
-      <RegExp conditional="Posters" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="15+">
+      <RegExp conditional="Posters" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="15+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;season&lt;/BannerType2&gt;</expression>
       </RegExp>
-      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
+      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;</expression>
       </RegExp>
-      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
+      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2</expression>
       </RegExp>
-      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
+      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2</expression>
       </RegExp>
-      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
+      <RegExp conditional="Banners" input="$$5" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="14+">
         <expression repeat="yes">(?i)&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;blank&lt;/BannerType2</expression>
       </RegExp>
       <RegExp input="" output="" dest="4">
@@ -1052,7 +1052,7 @@
       <RegExp input="$$7" output="\1" dest="4+">
         <expression repeat="yes" noclean="1">(?i)(&lt;(title|runtime|aired|credits|director|plot|thumb)[^&gt;]*&gt;.*?&lt;/\2&gt;)</expression>
       </RegExp>
-      <RegExp conditional="ExtraDetails" input="$$17" output="&lt;url function=&quot;GetEpisodeExtraDetailsDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="4+">
+      <RegExp conditional="ExtraDetails" input="$$17" output="&lt;url function=&quot;GetEpisodeExtraDetailsDataAPI&quot; cache=&quot;tvdb-$$20.xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;" dest="4+">
         <RegExp input="$$6" output="\1" dest="17">
           <expression clear="yes">(?i)tvdbid=&quot;([^&quot;]*)&quot;</expression>
         </RegExp>
@@ -1133,10 +1133,10 @@
       <RegExp input="$$1" output="\1" dest="6">
         <expression clear="yes" noclean="1">(?i)(&lt;episode&gt;\s*(?:&lt;([^&gt;]+)&gt;[^&lt;]*&lt;/\2&gt;\s*)*?&lt;episodename&gt;[^&lt;]+&lt;/episodename&gt;\s*(?:&lt;([^&gt;]+)&gt;[^&lt;]*&lt;/\3&gt;\s*)*?&lt;episodenumber&gt;$$13&lt;/episodenumber&gt;\s*(?:&lt;([^&gt;]+)&gt;[^&lt;]*&lt;/\4&gt;\s*)*?&lt;seasonnumber&gt;$$16&lt;/seasonnumber&gt;\s*(?:&lt;([^&gt;]+)&gt;[^&lt;]*&lt;/\5&gt;\s*)*?&lt;/episode&gt;)</expression>
       </RegExp>
-      <RegExp input="$$5" output="&lt;thumb&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
+      <RegExp input="$$5" output="&lt;thumb&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
         <expression clear="yes">(?i)&lt;filename&gt;([^&lt;]+)&lt;/filename&gt;</expression>
       </RegExp>
-      <RegExp input="$$13-$$6" output="&lt;thumb&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+      <RegExp input="$$13-$$6" output="&lt;thumb&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
         <expression>(?i)\d+-.*?&lt;filename&gt;([^&lt;]+)&lt;/filename&gt;</expression>
       </RegExp>
       <RegExp input="$$5" output="\1" dest="7">

--- a/metadata.anidb.net/resources/settings.xml
+++ b/metadata.anidb.net/resources/settings.xml
@@ -4,8 +4,8 @@
     <setting label="30000" type="bool" id="Google" default="false"/>
     <setting label="30005" type="labelenum" id="IdFrom" values="AniDB.net|TheTVDB.com" default="AniDB.net"/>
     <setting type="sep"/>
-    <setting label="30001" type="text" id="AnimeListUrl" default="http://sites.google.com/site/anidblist/anidb.xml"/>
-    <setting label="30002" type="text" id="AnimeMappingUrl" default="http://sites.google.com/site/anidblist/anime-list.xml"/>
+    <setting label="30001" type="text" id="AnimeListUrl" default="https://sites.google.com/site/anidblist/anidb.xml"/>
+    <setting label="30002" type="text" id="AnimeMappingUrl" default="https://sites.google.com/site/anidblist/anime-list.xml"/>
     <setting label="30003" type="bool" id="PersonalAnimeMapping" default="false"/>
     <setting label="30004" type="text" id="PersonalAnimeMappingUrl" default="http://localhost/pers-anime-list.xml" enable="eq(-1,true)"/>
   </category>

--- a/metadata.artists.universal/artistuniversal.xml
+++ b/metadata.artists.universal/artistuniversal.xml
@@ -2,7 +2,7 @@
 <scraper framework="1.1" date="2013-05-29">
 	<NfoUrl dest="3">
 		<RegExp input="$$1" output="&lt;url&gt;$INFO[mbsite]/ws/2/artist/\1?inc=url-rels&lt;/url&gt;" dest="3">
-			<expression>http://musicbrainz.org/artist/(.+)</expression>
+			<expression>https://musicbrainz.org/artist/(.+)</expression>
 		</RegExp>
 	</NfoUrl>
 	<ResolveIDToUrl dest="3">

--- a/metadata.artists.universal/resources/settings.xml
+++ b/metadata.artists.universal/resources/settings.xml
@@ -38,7 +38,7 @@
   </category>
   
   <category label="30025">
-      <setting label="30026" type="text" id="mbsite" default="http://musicbrainz.org"/>
+      <setting label="30026" type="text" id="mbsite" default="https://musicbrainz.org"/>
   </category>
 
 </settings>

--- a/metadata.bestanime.co.kr/bestanime.xml
+++ b/metadata.bestanime.co.kr/bestanime.xml
@@ -54,10 +54,10 @@
 			<RegExp input="$$3" output="&lt;url cache=&quot;bestanime-$$2.htm&quot; function=&quot;GetBestanimeId&quot;&gt;\1&lt;/url&gt;" dest="4+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTvdbIdByUrl&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=ko&lt;/url&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTvdbIdByUrl&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=ko&lt;/url&gt;" dest="4+">
 				<expression trim="1" encode="1">&lt;td[^&gt;]*&gt;&lt;img[^&gt;]*&gt;\s*¿µÁ¦&lt;/td&gt;\s*&lt;td[^&gt;]*&gt;(.*?)&lt;/td&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;anime-list.xml&quot; function=&quot;GetTvdbIdFromTbl&quot;&gt;http://xbmc-korean.googlecode.com/svn/trunk/tools/bestanime/anime-list.xml&lt;/url&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;anime-list.xml&quot; function=&quot;GetTvdbIdFromTbl&quot;&gt;https://xbmc-korean.googlecode.com/svn/trunk/tools/bestanime/anime-list.xml&lt;/url&gt;" dest="4+">
 				<expression/>
 			</RegExp>
 			<RegExp input="$$3" output="&lt;url cache=&quot;bestanime-$$2.htm&quot; function=&quot;GetTvdbDetails&quot;&gt;\1&lt;/url&gt;" dest="4+">
@@ -113,7 +113,7 @@
 			<RegExp input="$$8" output="&lt;episode&gt;\1&lt;/episode&gt;" dest="4+">
 				<expression>&lt;EpisodeNumber&gt;([^&lt;]*)&lt;/EpisodeNumber&gt;</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$8" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression>&lt;filename&gt;([^&lt;]+)&lt;/filename&gt;</expression>
 			</RegExp>
 			<RegExp input="$$8" output="&lt;aired&gt;\1&lt;/aired&gt;" dest="4+">
@@ -188,16 +188,16 @@
 	</GetTvdbIdFromTbl>
 	<GetTvdbDetails clearbuffers="no" dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbExtraDetails&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbExtraDetails&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbPosters&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbPosters&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbFanart&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;$$19.xml&quot; function=&quot;GetTvdbFanart&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="!useAgent" input="$$1" output="&lt;episodeguide&gt;&lt;url cache=&quot;$$19.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;&lt;/episodeguide&gt;" dest="5+">
+			<RegExp conditional="!useAgent" input="$$1" output="&lt;episodeguide&gt;&lt;url cache=&quot;$$19.xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$19/all/ko.zip&lt;/url&gt;&lt;/episodeguide&gt;" dest="5+">
 				<expression/>
 			</RegExp>
 			<expression noclean="1"/>
@@ -216,13 +216,13 @@
 	</GetTvdbExtraDetails>
 	<GetTvdbPosters clearbuffers="no" dest="3">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;thumb preview=&quot;http://www.thetvdb.com/banners/_cache/\1&quot;&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;thumb preview=&quot;https://www.thetvdb.com/banners/_cache/\1&quot;&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&gt;]*)&lt;/BannerPath&gt;\s*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb preview=&quot;http://www.thetvdb.com/banners/_cache/\1&quot;&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb preview=&quot;https://www.thetvdb.com/banners/_cache/\1&quot;&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&gt;]*)&lt;/BannerPath&gt;\s*&lt;BannerType&gt;season&lt;/BannerType&gt;.*?&lt;Season&gt;$$20&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb preview=&quot;http://www.thetvdb.com/banners/_cache/\1&quot;&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb preview=&quot;https://www.thetvdb.com/banners/_cache/\1&quot;&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&gt;]*)&lt;/BannerPath&gt;\s*&lt;BannerType&gt;series&lt;/BannerType&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -231,7 +231,7 @@
 	<GetTvdbFanart clearbuffers="no" dest="3">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<RegExp input="$$5" output="&lt;fanart&gt;\1&lt;/fanart&gt;" dest="4">
-				<RegExp input="$$1" output="&lt;thumb preview=&quot;http://www.thetvdb.com/banners/_cache/\1&quot;&gt;http://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5">
+				<RegExp input="$$1" output="&lt;thumb preview=&quot;https://www.thetvdb.com/banners/_cache/\1&quot;&gt;https://www.thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5">
 					<expression repeat="yes">&lt;BannerPath&gt;([^&gt;]*)&lt;/BannerPath&gt;\s*&lt;BannerType&gt;fanart&lt;/BannerType&gt;</expression>
 				</RegExp>
 				<expression noclean="1"/>

--- a/metadata.cinemagia.ro/cinemagia.xml
+++ b/metadata.cinemagia.ro/cinemagia.xml
@@ -2,7 +2,7 @@
     <scraper framework="1.1" date="2012-05-24">
 	<CreateSearchUrl SearchStringEncoding="utf-8" dest="3">
 		<!--movie search url on cinemagia.ro-->
-		<RegExp input="$$1" output="&lt;url&gt;http://www.cinemagia.ro/cauta/?q=\1&amp;amp;pn=99&amp;amp;search_type=filme&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://www.cinemagia.ro/cauta/?q=\1&amp;amp;pn=99&amp;amp;search_type=filme&lt;/url&gt;" dest="3">
 			<expression clear="yes" noclean="1" />
 		</RegExp>
 	</CreateSearchUrl>
@@ -10,7 +10,7 @@
 	<GetSearchResults dest="8">
 		<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="8">
 			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2 - \4&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url&gt;\1&lt;/url&gt;&lt;/entity&gt;" dest="5">
-				<expression repeat="yes" trim="1" noclean="1">search-item-container clearfix[^=]*..(http://www.cinemagia.ro/filme/[^"]*)[^=]*..([^"]*)[^(]*.(\d{4})[^&gt;]*.([^&lt;]*)</expression>
+				<expression repeat="yes" trim="1" noclean="1">search-item-container clearfix[^=]*..(https://www.cinemagia.ro/filme/[^"]*)[^=]*..([^"]*)[^(]*.(\d{4})[^&gt;]*.([^&lt;]*)</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -19,7 +19,7 @@
 		<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<!--ID IMDB-->
 			<RegExp input="$$1" output="\1" dest="12">
-				<expression noclean="1">http://www.imdb.com/title/tt([0-9]*)</expression>
+				<expression noclean="1">https://www.imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!--Title-->
 			<RegExp input="$$4" output="&lt;title&gt;\1&lt;/title&gt;" dest="5">
@@ -46,14 +46,14 @@
 				<RegExp input="$$1" output="\1" dest="4">
 					<expression noclean="1">&lt;h3&gt;Regia&lt;/h3&gt;(.*?)&lt;/li&gt;</expression>
 				</RegExp>
-				<expression repeat="yes" trim="1" noclean="1">&lt;a href="http://www.cinemagia.ro/actori/[^&gt;]*.([^&lt;]*)</expression>
+				<expression repeat="yes" trim="1" noclean="1">&lt;a href="https://www.cinemagia.ro/actori/[^&gt;]*.([^&lt;]*)</expression>
 			</RegExp>
 			<!--genre-->
 			<RegExp input="$$4" output="&lt;genre&gt;\1&lt;/genre&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="4">
 					<expression noclean="1">&lt;div id="movieGenreUserChoiceResults"&gt;(.*?)&lt;/ul&gt;</expression>
 				</RegExp>
-				<expression repeat="yes" trim="1" noclean="1">&lt;a href="http://www.cinemagia.ro/[^&gt;]*.([^&lt;]*)</expression>
+				<expression repeat="yes" trim="1" noclean="1">&lt;a href="https://www.cinemagia.ro/[^&gt;]*.([^&lt;]*)</expression>
 			</RegExp>
 			<!--rating (from cinemagia)-->
 			<RegExp conditional="!imdbrating" input="$$1" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="5+">
@@ -75,7 +75,7 @@
 				<expression noclean="1">Durata[^&gt;]*.&lt;span&gt;([0-9]*)</expression>
 			</RegExp>
 			<RegExp conditional="!fullmoviedistribution" input="$$1" output="&lt;actor&gt;&lt;name&gt;\3&lt;/name&gt;&lt;role&gt;\4&lt;/role&gt;&lt;thumb&gt;\1/db/actor/\2.jpg&lt;/thumb&gt;&lt;/actor&gt;" dest="5+">
-				<expression repeat="yes" noclean="1">&lt;a href="http://www.cinemagia.ro/actori/[^=]*."(http://[^/]*.[^/]*)/resize/db/actor/([^"]*(?=-))[^&lt;]*[^=]*[^/]*[^&gt;]*.([^&lt;]*)&lt;/a&gt;[^&lt;]*[^&gt;]*.([^&lt;]*)</expression>
+				<expression repeat="yes" noclean="1">&lt;a href="https://www.cinemagia.ro/actori/[^=]*."(https://[^/]*.[^/]*)/resize/db/actor/([^"]*(?=-))[^&lt;]*[^=]*[^/]*[^&gt;]*.([^&lt;]*)&lt;/a&gt;[^&lt;]*[^&gt;]*.([^&lt;]*)</expression>
 			</RegExp>
 			<RegExp conditional="fullmoviedistribution" input="$$3" output="&lt;url function=&quot;GetFullMovieDistribution&quot;&gt;$$3distributie/&lt;/url&gt;" dest="5+">
 				<expression />
@@ -84,7 +84,7 @@
 				<expression />
 			</RegExp>
 			<RegExp conditional="!tmdbthumbs" input="$$1" output="&lt;thumb&gt;\1&lt;/thumb&gt;" dest="5+">
-				<expression>&lt;a href="(http://static.cinemagia.ro/img/db/movie/[^"]*)</expression>
+				<expression>&lt;a href="(https://static.cinemagia.ro/img/db/movie/[^"]*)</expression>
 			</RegExp>
 			<RegExp conditional="tmdbthumbs" input="$$12" output="&lt;chain function=&quot;GetTMDBThumbsByIdChain&quot;&gt;tt\1&lt;/chain&gt;" dest="5+">
 				<expression />

--- a/metadata.cinemarx.ro/cinemarx.xml
+++ b/metadata.cinemarx.ro/cinemarx.xml
@@ -112,7 +112,7 @@
 				<expression noclean="1" />
 			</RegExp>
 			<!--IMDB search-->
-			<RegExp input="$$4" output="&lt;url function=&quot;GetIMDBRatingTMDBThumbnailFanart&quot;&gt;http://www.google.com/search?hl=en&amp;as_q=\1&amp;ft=i&amp;as_sitesearch=imdb.com&amp;as_qdr=all&amp;as_occt=any&amp;num=1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$4" output="&lt;url function=&quot;GetIMDBRatingTMDBThumbnailFanart&quot;&gt;https://www.google.com/search?hl=en&amp;as_q=\1&amp;ft=i&amp;as_sitesearch=imdb.com&amp;as_qdr=all&amp;as_occt=any&amp;num=1&lt;/url&gt;" dest="5+">
 				<RegExp input="imdb/title $$11 $$12 $$13" output="\1" dest="4">
 					<expression noclean="1" encode="1" />
 				</RegExp>
@@ -132,7 +132,7 @@
 		<RegExp input="$$4" output="&lt;details&gt;$$4&lt;/details&gt;" dest="5">
 			<!--save IMDB ID-->
 			<RegExp input="$$1" output="\1" dest="7">
-				<expression noclean="1">http://www.imdb.com/title/(tt[0-9]*)</expression>
+				<expression noclean="1">https://www.imdb.com/title/(tt[0-9]*)</expression>
 			</RegExp>
 			<!--rating from IMDB-->
 			<RegExp conditional="imdbrating" input="" output="&lt;chain function=&quot;GetIMDBRatingById&quot;&gt;$$7&lt;/chain&gt;" dest="4">

--- a/metadata.common.allmusic.com/allmusic.xml
+++ b/metadata.common.allmusic.com/allmusic.xml
@@ -334,8 +334,8 @@
 			<RegExp input="$$1" output="\1" dest="4">
 				<expression noclean="1">&lt;h\d&gt;Photo\sGallery&lt;/h\d&gt;(.*?)&lt;h2\sclass=&quot;artist-name&quot;</expression>
 			</RegExp>
-			<RegExp input="$$4" output="&lt;thumb&gt;http://cps-static.rovicorp.com/3/JPG_1080/\1&lt;/thumb&gt;" dest="2">
-				<expression repeat="yes" noclean="1">&lt;img src=&quot;http://cps-static.rovicorp.com/3/JPG_[^/]*/([^&quot;]*)</expression>
+			<RegExp input="$$4" output="&lt;thumb&gt;https://cps-static.rovicorp.com/3/JPG_1080/\1&lt;/thumb&gt;" dest="2">
+				<expression repeat="yes" noclean="1">&lt;img src=&quot;https://cps-static.rovicorp.com/3/JPG_[^/]*/([^&quot;]*)</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -504,8 +504,8 @@
 	</GetAMGAlbumThumbsByAMGID>
 	<ParseAMGAlbumThumbs dest="5">
 		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;thumb&gt;http://cps-static.rovicorp.com/3/JPG_500/\1&lt;/thumb&gt;" dest="2">
-				<expression noclean="1">&quot;http://cps-static.rovicorp.com/3/JPG_[^/]*/([^&quot;]*)</expression>
+			<RegExp input="$$1" output="&lt;thumb&gt;https://cps-static.rovicorp.com/3/JPG_500/\1&lt;/thumb&gt;" dest="2">
+				<expression noclean="1">&quot;https://cps-static.rovicorp.com/3/JPG_[^/]*/([^&quot;]*)</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>

--- a/metadata.common.amazon.de/amazonde.xml
+++ b/metadata.common.amazon.de/amazonde.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraperfunctions>
 	<GetAmazonDEAlbumReviewByASIN dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseAmazonDEAlbumReview&quot;&gt;http://www.amazon.de/exec/obidos/ASIN/\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseAmazonDEAlbumReview&quot;&gt;https://www.amazon.de/exec/obidos/ASIN/\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1">(.+)</expression>
 		</RegExp>
 	</GetAmazonDEAlbumReviewByASIN>

--- a/metadata.common.fanart.tv/fanarttv.xml
+++ b/metadata.common.fanart.tv/fanarttv.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraperfunctions>
 	<GetFanartTvArtistThumbsByMBID dest="5" clearbuffers="no">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvArtistThumbs&quot; cache=&quot;fanarttv-artistimages-\1.json&quot;&gt;http://webservice.fanart.tv/v3/music/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvArtistThumbs&quot; cache=&quot;fanarttv-artistimages-\1.json&quot;&gt;https://webservice.fanart.tv/v3/music/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetFanartTvArtistThumbsByMBID>
@@ -24,7 +24,7 @@
 	</ParseFanartTvArtistThumbs>
 
 	<GetFanartTvArtistFanartsByMBID dest="5" clearbuffers="no">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvArtistFanarts&quot; cache=&quot;fanarttv-artistimages-\1.json&quot;&gt;http://webservice.fanart.tv/v3/music/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvArtistFanarts&quot; cache=&quot;fanarttv-artistimages-\1.json&quot;&gt;https://webservice.fanart.tv/v3/music/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetFanartTvArtistFanartsByMBID>
@@ -53,7 +53,7 @@
 	</ParseFanartTvArtistFanarts>
 
 	<GetFanartTvAlbumThumbsByMBID dest="5" clearbuffers="no">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvAlbumThumbs&quot; cache=&quot;fanarttv-albumimages-\1.json&quot;&gt;http://webservice.fanart.tv/v3/music/albums/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseFanartTvAlbumThumbs&quot; cache=&quot;fanarttv-albumimages-\1.json&quot;&gt;https://webservice.fanart.tv/v3/music/albums/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetFanartTvAlbumThumbsByMBID>
@@ -77,7 +77,7 @@
 
 	<GetFanartTvFanartByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseFanartTvFanart&quot; cache=&quot;fanarttv-\1.json&quot;&gt;http://webservice.fanart.tv/v3/movies/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseFanartTvFanart&quot; cache=&quot;fanarttv-\1.json&quot;&gt;https://webservice.fanart.tv/v3/movies/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -109,7 +109,7 @@
 
 	<GetFanartTvThumbsByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseFanartTvThumbs&quot; cache=&quot;fanarttv-\1.json&quot;&gt;http://webservice.fanart.tv/v3/movies/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseFanartTvThumbs&quot; cache=&quot;fanarttv-\1.json&quot;&gt;https://webservice.fanart.tv/v3/movies/\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />

--- a/metadata.common.imdb.com/imdb.xml
+++ b/metadata.common.imdb.com/imdb.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <scraperfunctions>
 	<GetIMDBGenresById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBGenres&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBGenres&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBGenresById>
@@ -15,7 +15,7 @@
 	</ParseIMDBGenres>
 
 	<GetIMDBRatingById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBRating&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBRating&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBRatingById>
@@ -29,7 +29,7 @@
 	</ParseIMDBRating>
 
 	<GetIMDBTOP250ById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBTOP250&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBTOP250&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBTOP250ById>
@@ -43,7 +43,7 @@
 	</ParseIMDBTOP250>
 
 	<GetIMDBStudioById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBStudio&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBStudio&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBStudioById>
@@ -57,7 +57,7 @@
 	</ParseIMDBStudio>
 
 	<GetIMDBCountryById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBCountry&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBCountry&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBCountryById>
@@ -71,7 +71,7 @@
 	</ParseIMDBCountry>
 
 	<GetMetaCriticRatingById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseMetaCriticRating&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseMetaCriticRating&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetMetaCriticRatingById>
@@ -85,7 +85,7 @@
 	</ParseMetaCriticRating>
 
 	<GetIMDBPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBPlot&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBPlot&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBPlotById>
@@ -99,7 +99,7 @@
 	</ParseIMDBPlot>
 
 	<GetIMDBTaglineById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBTagline&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBTagline&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBTaglineById>
@@ -113,7 +113,7 @@
 	</ParseIMDBTagline>
 
 	<GetIMDBOutlineById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBOutline&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBOutline&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBOutlineById>
@@ -127,7 +127,7 @@
 	</ParseIMDBOutline>
 
 	<GetIMDBOutlineToPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBOutlineToPlot&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBOutlineToPlot&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBOutlineToPlotById>
@@ -141,7 +141,7 @@
 	</ParseIMDBOutlineToPlot>
 
 	<GetIMDBCastById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBCast&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBCast&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBCastById>
@@ -164,7 +164,7 @@
 	</ParseIMDBCast>
 
 	<GetIMDBDirectorsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBDirectors&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBDirectors&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBDirectorsById>
@@ -181,7 +181,7 @@
 	</ParseIMDBDirectors>
 
 	<GetIMDBWritersById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBWriters&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBWriters&quot;&gt;https://www.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBWritersById>
@@ -198,7 +198,7 @@
 	</ParseIMDBWriters>
 
 	<GetIMDBFullCastById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullCast&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullCast&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBFullCastById>
@@ -218,7 +218,7 @@
 	</ParseIMDBFullCast>
 
 	<GetIMDBFullDirectorsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullDirectors&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullDirectors&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBFullDirectorsById>
@@ -235,7 +235,7 @@
 	</ParseIMDBFullDirectors>
 
 	<GetIMDBFullWritersById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullWriters&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBFullWriters&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBFullWritersById>
@@ -252,7 +252,7 @@
 	</ParseIMDBFullWriters>
 
 	<GetIMDBThumbsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-posters.html&quot; function=&quot;ParseIMDBThumbs&quot;&gt;http://akas.imdb.com/title/$$1/posters|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-posters.html&quot; function=&quot;ParseIMDBThumbs&quot;&gt;https://www.imdb.com/title/$$1/posters|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBThumbsById>
@@ -269,7 +269,7 @@
 	</ParseIMDBThumbs>
 
 	<GetIMDBUSACert dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBUSACert&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBUSACert&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBUSACert>
@@ -280,7 +280,7 @@
 	</ParseIMDBUSACert>
 
 	<GetIMDBCountryCert dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBCountryCert&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBCountryCert&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBCountryCert>
@@ -291,7 +291,7 @@
 	</ParseIMDBCountryCert>
 
 	<GetIMDBAKATitlesById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBAKATitles&quot;&gt;http://akas.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-combined.html&quot; function=&quot;ParseIMDBAKATitles&quot;&gt;https://www.imdb.com/title/$$1/combined|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetIMDBAKATitlesById>

--- a/metadata.common.impa.com/impa.xml
+++ b/metadata.common.impa.com/impa.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraperfunctions>
 	<GetIMPAThumbsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-posters.html&quot; function=&quot;GetIMPALink&quot;&gt;http://www.imdb.com/title/$$1/posters&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-posters.html&quot; function=&quot;GetIMPALink&quot;&gt;https://www.imdb.com/title/$$1/posters&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression />
 		</RegExp>
 	</GetIMPAThumbsById>
 	<GetIMPALink dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseIMPAThumbs&quot;&gt;http://\1impawards.com/\2&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1,2">http://([^&quot;]*)impawards.com/([^&quot;]*)&quot;&gt;</expression>
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseIMPAThumbs&quot;&gt;https://\1impawards.com/\2&lt;/url&gt;&lt;/details&gt;" dest="5">
+			<expression noclean="1,2">https://([^&quot;]*)impawards.com/([^&quot;]*)&quot;&gt;</expression>
 		</RegExp>
 	</GetIMPALink>
 	<ParseIMPAThumbs dest="6">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="6">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseIMPAThumbs&quot;&gt;http://www.impawards.com/\1&lt;/url&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseIMPAThumbs&quot;&gt;https://www.impawards.com/\1&lt;/url&gt;" dest="4">
 				<expression noclean="1">&lt;meta\shttp-equiv=&quot;REFRESH&quot;\scontent=&quot;0;URL=[^/]*/([^&quot;]*)&quot;&gt;</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="8">
-				<expression noclean="1">value\s=\s&quot;&lt;a\shref\s=\shttp://www.impawards.com/([0-9]*)/</expression>
+				<expression noclean="1">value\s=\s&quot;&lt;a\shref\s=\shttps://www.impawards.com/([0-9]*)/</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://www.impawards.com/$$8/posters/\2&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://www.impawards.com/$$8/posters/\2&lt;/thumb&gt;" dest="4+">
 				<expression noclean="1">&lt;img\s(SRC|src)=&quot;posters/([^&quot;]*)&quot;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://www.impawards.com/$$8/posters/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://www.impawards.com/$$8/posters/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes" noclean="1">thumbs/imp_([^&gt;]*ver[^&gt;]*.jpg)&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>

--- a/metadata.common.movie.daum.net/daum-movie.xml
+++ b/metadata.common.movie.daum.net/daum-movie.xml
@@ -7,7 +7,7 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포스터 리스트&lt;/h3&gt;.*&lt;span class="current"&gt;(.*)&lt;!-- 포스터 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;url function=&quot;GetDaumPosterPage&quot;&gt;http://movie.daum.net/\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$6" output="&lt;url function=&quot;GetDaumPosterPage&quot;&gt;https://movie.daum.net/\1&lt;/url&gt;" dest="5+">
 				<expression repeat="yes" noclean="1">&lt;a href="([^"]*)"&gt;(\d+)&lt;/a&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -18,8 +18,8 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포스터 리스트&lt;/h3&gt;(.*)&lt;!-- 포스터 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;thumb preview=&quot;http://\1/C155x225/\2&quot;&gt;http://\1/image/\2&lt;/thumb&gt;" dest="5">
-				<expression repeat="yes" noclean="1">&lt;img src="http://([^/]+)/C155x225/([^"]+)"</expression>
+			<RegExp input="$$6" output="&lt;thumb preview=&quot;https://\1/C155x225/\2&quot;&gt;https://\1/image/\2&lt;/thumb&gt;" dest="5">
+				<expression repeat="yes" noclean="1">&lt;img src="https://([^/]+)/C155x225/([^"]+)"</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -29,7 +29,7 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포토 리스트&lt;/h3&gt;.*&lt;span class="current"&gt;(.*)&lt;!-- 포토 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;url function=&quot;GetDaumFanartPage2&quot;&gt;http://movie.daum.net\1&lt;/url&gt;" dest="5">
+			<RegExp input="$$6" output="&lt;url function=&quot;GetDaumFanartPage2&quot;&gt;https://movie.daum.net\1&lt;/url&gt;" dest="5">
 				<expression repeat="yes" noclean="1">&lt;a href="([^"]*)"&gt;(\d+)&lt;/a&gt;</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;url cache=&quot;daum-photo-\2.htm&quot; function=&quot;GetDaumFanartPage&quot;&gt;\1movieId=\2\3&lt;/url&gt;" dest="5+">
@@ -44,8 +44,8 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포토 리스트&lt;/h3&gt;(.*)&lt;!-- 포토 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;thumb preview=&quot;http://\1/S150x125/\2&quot;&gt;http://\1/image/\2&lt;/thumb&gt;" dest="5">
-				<expression repeat="yes" noclean="1">&lt;img src="http://([^/]+)/S150x125/([^"]+)"</expression>
+			<RegExp input="$$6" output="&lt;thumb preview=&quot;https://\1/S150x125/\2&quot;&gt;https://\1/image/\2&lt;/thumb&gt;" dest="5">
+				<expression repeat="yes" noclean="1">&lt;img src="https://([^/]+)/S150x125/([^"]+)"</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -55,8 +55,8 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포토 리스트&lt;/h3&gt;(.*)&lt;!-- 포토 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;thumb preview=&quot;http://\1/S150x125/\2&quot;&gt;http://\1/image/\2&lt;/thumb&gt;" dest="10+">
-				<expression repeat="yes" noclean="1">&lt;img src="http://([^/]+)/S150x125/([^"]+)"</expression>
+			<RegExp input="$$6" output="&lt;thumb preview=&quot;https://\1/S150x125/\2&quot;&gt;https://\1/image/\2&lt;/thumb&gt;" dest="10+">
+				<expression repeat="yes" noclean="1">&lt;img src="https://([^/]+)/S150x125/([^"]+)"</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -106,10 +106,10 @@
 	<!-- Modify after copying from common/tmdb.xml -->
 	<GetTMDBFanartById dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBFanart&quot; cache=&quot;tmdb-images-tt\1.xml&quot;&gt;http://api.themoviedb.org/2.1/Movie.getImages/en/xml/57983e31fb435df4df77afb854740ea9/tt\1&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBFanart&quot; cache=&quot;tmdb-images-tt\1.xml&quot;&gt;https://api.themoviedb.org/2.1/Movie.getImages/en/xml/57983e31fb435df4df77afb854740ea9/tt\1&lt;/url&gt;" dest="5">
 				<expression>/tt([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBFanart&quot; cache=&quot;tmdb-images-\1.xml&quot;&gt;http://api.themoviedb.org/2.1/Movie.getImages/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBFanart&quot; cache=&quot;tmdb-images-\1.xml&quot;&gt;https://api.themoviedb.org/2.1/Movie.getImages/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5">
 				<expression>&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>

--- a/metadata.common.omdbapi.com/omdbapi.xml
+++ b/metadata.common.omdbapi.com/omdbapi.xml
@@ -1,7 +1,7 @@
 ﻿<scraperfunctions>
 	<!-- Get OMDBAPI URL from IMDb ID for ratings -->
 	<GetRTRatingById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;https://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<RegExp input="$INFO[tomato]" output="Tom" dest="10">
 				<expression>TomatoMeter</expression>
 			</RegExp>
@@ -48,7 +48,7 @@
 
 	<!-- Critics' Consensus -->
 	<GetRTOutlineById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTOutline$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTOutline$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;https://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTOutlineById>
@@ -63,7 +63,7 @@
 
 	<!-- Critics' Consensus -->
 	<GetRTCConsensusToPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTCConsensusToPlot$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTCConsensusToPlot$$10&quot; cache=&quot;\1-omdbapi.html&quot;&gt;https://www.omdbapi.com/?i=tt\1&amp;r=json&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTCConsensusToPlotById>
@@ -78,7 +78,7 @@
 
 	<!-- Plot (NOT ACTIVE)-->
 	<GetRTPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTPlot&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTPlot&quot; cache=&quot;\1-omdbapi.html&quot;&gt;https://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTPlotById>

--- a/metadata.common.port.hu/porthu.xml
+++ b/metadata.common.port.hu/porthu.xml
@@ -38,7 +38,7 @@
 			<RegExp input="$$18" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="2">
 				<expression>(.+)</expression>
 			</RegExp>
-			<RegExp input="$$18" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-hu-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=hu&lt;/url&gt;" dest="2">
+			<RegExp input="$$18" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-hu-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=hu&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;url function=&quot;ParsePortHUPlot&quot; cache=&quot;porthu-\1.html&quot;&gt;http://www.port.hu/pls/fi/films.film_page?i_where=2&amp;i_film_id=\1&lt;/url&gt;" dest="2">
@@ -52,7 +52,7 @@
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression>&lt;div id="text_articol"&gt;\n&lt;span class="txt"&gt;(.*?)&lt;/span&gt;</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=en&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8?api_key=57983e31fb435df4df77afb854740ea9&amp;amp;language=en&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="2">

--- a/metadata.common.rt.com/rt.xml
+++ b/metadata.common.rt.com/rt.xml
@@ -1,7 +1,7 @@
 ﻿<scraperfunctions>
 	<!-- Get Rotten Tomatoes URL from IMDb ID for ratings -->
 	<GetRTRatingById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10&quot; cache=&quot;\1-rt.html&quot;&gt;http://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10&quot; cache=&quot;\1-rt.html&quot;&gt;https://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<RegExp input="$INFO[tomato]" output="Tom" dest="10">
 				<expression>TomatoMeter</expression>
 			</RegExp>
@@ -56,7 +56,7 @@
 
 	<!-- Critics' Consensus -->
 	<GetRTOutlineById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTOutline&quot; cache=&quot;\1-rt.html&quot;&gt;http://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTOutline&quot; cache=&quot;\1-rt.html&quot;&gt;https://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTOutlineById>
@@ -71,7 +71,7 @@
 
 	<!-- Critics' Consensus -->
 	<GetRTCConsensusToPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTCConsensusToPlot&quot; cache=&quot;\1-rt.html&quot;&gt;http://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTCConsensusToPlot&quot; cache=&quot;\1-rt.html&quot;&gt;https://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTCConsensusToPlotById>
@@ -86,7 +86,7 @@
 
 	<!-- Plot -->
 	<GetRTPlotById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTPlot&quot; cache=&quot;\1-rt.html&quot;&gt;http://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRTPlot&quot; cache=&quot;\1-rt.html&quot;&gt;https://www.rottentomatoes.com/alias?type=imdbid&amp;s=\1&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTPlotById>

--- a/metadata.common.themoviedb.org/tmdb.xml
+++ b/metadata.common.themoviedb.org/tmdb.xml
@@ -3,7 +3,7 @@
 
 	<GetTMDBCertificationsByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCertifications&quot; cache=&quot;tmdb-cert-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/releases?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbcertcountry]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCertifications&quot; cache=&quot;tmdb-cert-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/releases?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbcertcountry]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -20,7 +20,7 @@
 
 	<GetTMDBTitleByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTitle&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTitle&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -28,7 +28,7 @@
 	</GetTMDBTitleByIdChain>
 	<GetTMDBLangTitleByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTitle&quot; cache=&quot;tmdb-$INFO[tmdbtitlelanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtitlelanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTitle&quot; cache=&quot;tmdb-$INFO[tmdbtitlelanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtitlelanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -48,7 +48,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -59,7 +59,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-$INFO[tmdbplotlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbplotlanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBPlot&quot; cache=&quot;tmdb-$INFO[tmdbplotlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbplotlanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -70,7 +70,7 @@
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression clear="yes" fixchars="1">&quot;overview&quot;:&quot;(.*?)&quot;,&quot;</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="2">
@@ -93,7 +93,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTagline&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTagline&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -104,7 +104,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTagline&quot; cache=&quot;tmdb-$INFO[tmdbtaglinelanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtaglinelanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTagline&quot; cache=&quot;tmdb-$INFO[tmdbtaglinelanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtaglinelanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -115,7 +115,7 @@
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression clear="yes" fixchars="1">&quot;tagline&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBTagline&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBTagline&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;tagline&gt;\1&lt;/tagline&gt;" dest="2">
@@ -138,7 +138,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTags&quot; &gt;http://api.tmdb.org/3/movie/\1/keywords?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBTags&quot; &gt;https://api.tmdb.org/3/movie/\1/keywords?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -158,7 +158,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBSet&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBSet&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -169,7 +169,7 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression clear="yes" noclean="1" />
 			</RegExp>
-			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBSet&quot; cache=&quot;tmdb-$INFO[tmdbsetlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsetlanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$8" output="&lt;url function=&quot;ParseTMDBSet&quot; cache=&quot;tmdb-$INFO[tmdbsetlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsetlanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -180,7 +180,7 @@
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression clear="yes" noclean="1">&quot;belongs_to_collection&quot;:\{&quot;id&quot;:[0-9]+,&quot;name&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBSet&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseFallbackTMDBSet&quot; cache=&quot;tmdb-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;set&gt;\1&lt;/set&gt;" dest="2">
@@ -200,10 +200,10 @@
 
 	<GetTMDBCastByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCast&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCast&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -226,7 +226,7 @@
 
 	<GetTMDBDirectorsByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBDirectors&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBDirectors&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -246,7 +246,7 @@
 
 	<GetTMDBWitersByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBWriters&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBWriters&quot; cache=&quot;tmdb-cast-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/casts?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -266,7 +266,7 @@
 
 	<GetTMDBGenresByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBGenres&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBGenres&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -274,7 +274,7 @@
 	</GetTMDBGenresByIdChain>
 	<GetTMDBLangGenresByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBGenres&quot; cache=&quot;tmdb-$INFO[tmdbgenreslanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbgenreslanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBGenres&quot; cache=&quot;tmdb-$INFO[tmdbgenreslanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbgenreslanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -294,7 +294,7 @@
 
 	<GetTMDBRatingByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBRating&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBRating&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -314,7 +314,7 @@
 
 	<GetTMDBStudioByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBStudio&quot; cache=&quot;tmdb-en-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBStudio&quot; cache=&quot;tmdb-en-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -334,7 +334,7 @@
 
 	<GetTMDBCountryByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCountry&quot; cache=&quot;tmdb-en-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBCountry&quot; cache=&quot;tmdb-en-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -354,7 +354,7 @@
 
 	<GetTMDBTrailerByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTrailer&quot; cache=&quot;tmdb-trailer-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTrailer&quot; cache=&quot;tmdb-trailer-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -362,7 +362,7 @@
 	</GetTMDBTrailerByIdChain>
 	<GetTMDBLangTrailerByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTrailer&quot; cache=&quot;tmdb-trailer-$INFO[tmdbtrailerlanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtrailerlanguage]&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBTrailer&quot; cache=&quot;tmdb-trailer-$INFO[tmdbtrailerlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbtrailerlanguage]&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -379,7 +379,7 @@
 			<RegExp input="$$7" output="&lt;trailer&gt;plugin://plugin.video.youtube/?action=play_video&amp;amp;videoid=\1&lt;/trailer&gt;" dest="9">
 				<expression noclean="1">&quot;source&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBEnTrailer&quot; cache=&quot;tmdb-trailer-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBEnTrailer&quot; cache=&quot;tmdb-trailer-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/trailers?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$9" dest="2">
@@ -399,7 +399,7 @@
 			<RegExp input="$$7" output="&lt;trailer&gt;plugin://plugin.video.youtube/?action=play_video&amp;amp;videoid=\1&lt;/trailer&gt;" dest="9">
 				<expression noclean="1">&quot;source&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBAllTrailer&quot; cache=&quot;tmdb-trailer-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/trailers?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBAllTrailer&quot; cache=&quot;tmdb-trailer-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/trailers?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$9" dest="2">
@@ -422,10 +422,10 @@
 
 	<GetTMDBFanartByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBFanart&quot; cache=&quot;tmdb-images-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBFanart&quot; cache=&quot;tmdb-images-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -445,10 +445,10 @@
 
 	<GetTMDBThumbsByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBThumbs&quot; cache=&quot;tmdb-images-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBThumbs&quot; cache=&quot;tmdb-images-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -456,10 +456,10 @@
 	</GetTMDBThumbsByIdChain>
 	<GetTMDBLangThumbsByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.tmdb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBLangThumbs&quot; cache=&quot;tmdb-images-$INFO[tmdbthumblanguage]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbthumblanguage]&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBLangThumbs&quot; cache=&quot;tmdb-images-$INFO[tmdbthumblanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbthumblanguage]&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -480,12 +480,12 @@
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$12" dest="2+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="12">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="12">
 					<expression>en</expression>
 				</RegExp>
 				<expression>^$</expression>
 			</RegExp>
-			<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseTMDBEnThumbs&quot; cache=&quot;tmdb-images-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2+">
+			<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseTMDBEnThumbs&quot; cache=&quot;tmdb-images-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2+">
 				<expression>^((?!en).)*$</expression>
 			</RegExp>
 			<expression noclean="1">(.+)</expression>
@@ -506,12 +506,12 @@
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$12" dest="2+">
-				<RegExp input="$INFO[tmdbthumblanguage]" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="12">
+				<RegExp input="$INFO[tmdbthumblanguage]" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="12">
 					<expression>en</expression>
 				</RegExp>
 				<expression>^$</expression>
 			</RegExp>
-			<RegExp input="$INFO[tmdbthumblanguage]" output="&lt;url function=&quot;ParseTMDBEnThumbs&quot; cache=&quot;tmdb-images-en-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2+">
+			<RegExp input="$INFO[tmdbthumblanguage]" output="&lt;url function=&quot;ParseTMDBEnThumbs&quot; cache=&quot;tmdb-images-en-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="2+">
 				<expression>^((?!en).)*$</expression>
 			</RegExp>
 			<expression noclean="1">(.+)</expression>
@@ -531,7 +531,7 @@
 			<RegExp input="$$9" output="$$9" dest="2">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
-			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;http://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="2">
+			<RegExp input="$$9" output="&lt;url function=&quot;ParseTMDBAllThumbs&quot; cache=&quot;tmdb-images-$$8.json&quot;&gt;https://api.tmdb.org/3/movie/$$8/images?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="2">
 				<expression>^$</expression>
 			</RegExp>
 			<expression noclean="1">(.+)</expression>

--- a/metadata.common.youtubetrailers/youtube.xml
+++ b/metadata.common.youtubetrailers/youtube.xml
@@ -1,6 +1,6 @@
 <scraperfunctions>
     <GetYoutubeTrailer dest="3">
-    <RegExp input="$$6" output="&lt;details&gt;&lt;url function=&quot;ParseSDTrailer&quot; cache=&quot;youtubetrailers-\1.xml&quot;&gt;http://www.youtube.com/results?search_query=%22\1%22+$$9+trailer+hd+-peek+-remake+-deutsch+-fan-made&amp;search_duration=short&amp;hl=fr-FR&amp;persist_hl=1&lt;/url&gt;&lt;/details&gt;" dest="3">
+    <RegExp input="$$6" output="&lt;details&gt;&lt;url function=&quot;ParseSDTrailer&quot; cache=&quot;youtubetrailers-\1.xml&quot;&gt;https://www.youtube.com/results?search_query=%22\1%22+$$9+trailer+hd+-peek+-remake+-deutsch+-fan-made&amp;search_duration=short&amp;hl=fr-FR&amp;persist_hl=1&lt;/url&gt;&lt;/details&gt;" dest="3">
 
       <RegExp input="$$6" output="\1%C3%A0\2" dest="6">
         <RegExp input="$$6" output="\1%C3%A2\2" dest="6">

--- a/metadata.disneyinfo.nl/disneyinfo.xml
+++ b/metadata.disneyinfo.nl/disneyinfo.xml
@@ -26,10 +26,10 @@
 			<RegExp input="$$1" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="3+">
 				<expression>Synopsis&lt;/th&gt;.*&lt;td width='100\%' class='row1' colspan='2'&gt;(.*?)&lt;/td&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetTMDBFanartByIdChain&quot;&gt;http://www.imdb.com/title/tt\1&lt;/chain&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetTMDBFanartByIdChain&quot;&gt;https://www.imdb.com/title/tt\1&lt;/chain&gt;" dest="3+">
 				<expression>imdb.com/title/tt(\d*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetTMDBThumbsByIdChain&quot;&gt;http://www.imdb.com/title/tt\1&lt;/chain&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetTMDBThumbsByIdChain&quot;&gt;https://www.imdb.com/title/tt\1&lt;/chain&gt;" dest="3+">
 				<expression>imdb.com/title/tt(\d*)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="3+">

--- a/metadata.douban.com/douban.xml
+++ b/metadata.douban.com/douban.xml
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2013-05-21">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;GetUrlByIMDBId&quot;&gt;http://movie.douban.com/j/subject_suggest?q=tt\1&lt;/url&gt;&lt;details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;GetUrlByIMDBId&quot;&gt;https://movie.douban.com/j/subject_suggest?q=tt\1&lt;/url&gt;&lt;details&gt;" dest="3">
 			<expression>imdb....?/title/tt([0-9]*)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;GetUrlByIMDBId&quot;&gt;http://movie.douban.com/j/subject_suggest?q=tt\1&lt;/url&gt;&lt;details&gt;" dest="3+">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;GetUrlByIMDBId&quot;&gt;https://movie.douban.com/j/subject_suggest?q=tt\1&lt;/url&gt;&lt;details&gt;" dest="3+">
 			<expression>imdb....?/Title\?([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
 	<GetUrlByIMDBId dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url&gt;http://api.douban.com/v2/movie/subject/\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url&gt;https://api.douban.com/v2/movie/subject/\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;details&gt;" dest="3">
 			<expression>&quot;url&quot;:&quot;http:\\/\\/movie.douban.com\\/subject\\/([0-9]+)\\/[^&quot;]*&quot;</expression>
 		</RegExp>
 	</GetUrlByIMDBId>
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://api.douban.com/v2/movie/search?q=\1&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://api.douban.com/v2/movie/search?q=\1&lt;/url&gt;" dest="3">
 			<expression noclean="1"/>
 		</RegExp>
 	</CreateSearchUrl>
 	<GetSearchResults dest="8">
 		<RegExp input="$$3" output="&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1 - \2 (\3)&lt;/title&gt;&lt;url&gt;http://api.douban.com/v2/movie/subject/\4&lt;/url&gt;&lt;id&gt;\4&lt;/id&gt;&lt;/entity&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1 - \2 (\3)&lt;/title&gt;&lt;url&gt;https://api.douban.com/v2/movie/subject/\4&lt;/url&gt;&lt;id&gt;\4&lt;/id&gt;&lt;/entity&gt;" dest="3+">
 				<expression repeat="yes">&quot;title&quot;: &quot;([^&quot;]*)&quot;, &quot;casts&quot;: \[[^\]]*\], &quot;collect_count&quot;: [0-9]*, &quot;original_title&quot;: &quot;([^&quot;]*)&quot;, &quot;subtype&quot;: &quot;movie&quot;, &quot;directors&quot;: \[[^\]]*\], &quot;year&quot;: &quot;(\d*)&quot;, &quot;images&quot;: \{[^\}]*\}, &quot;alt&quot;: &quot;[^&quot;]*&quot;, &quot;id&quot;: &quot;(\d*)&quot;</expression>
 			</RegExp>
 			<expression noclean="1" fixchars="1"/>
@@ -76,8 +76,8 @@
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression noclean="1" clear="yes" fixchars="1">&quot;casts&quot;: \[(.+?)\]</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;actor&gt;&lt;thumb&gt;http://\2/img/celebrity/large/\3.jpg&lt;/thumb&gt;&lt;name&gt;\4&lt;/name&gt;&lt;/actor&gt;" dest="5+">
-				<expression noclean="1" repeat="yes">&quot;avatars&quot;: (null|.*?&quot;large&quot;: &quot;http://(.+?)\\/img\\/celebrity\\/large\\/(.+?).jpg&quot;[^\}]*\}), &quot;name&quot;: &quot;(.+?)&quot;</expression>
+			<RegExp input="$$8" output="&lt;actor&gt;&lt;thumb&gt;https://\2/img/celebrity/large/\3.jpg&lt;/thumb&gt;&lt;name&gt;\4&lt;/name&gt;&lt;/actor&gt;" dest="5+">
+				<expression noclean="1" repeat="yes">&quot;avatars&quot;: (null|.*?&quot;large&quot;: &quot;https://(.+?)\\/img\\/celebrity\\/large\\/(.+?).jpg&quot;[^\}]*\}), &quot;name&quot;: &quot;(.+?)&quot;</expression>
 			</RegExp>
 			<RegExp input="$$2" output="&lt;url cache=&quot;\1-poster.html&quot; function=&quot;GetPoster&quot;&gt;https://movie.douban.com/subject/\1/photos?type=R&lt;/url&gt;" dest="5+">
 				<expression/>
@@ -85,7 +85,7 @@
 			<RegExp conditional="!tmdbfanart" input="$$2" output="&lt;url cache=&quot;\1-fanart.html&quot; function=&quot;GetFanart&quot;&gt;https://movie.douban.com/subject/\1/photos?type=S&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;url function=&quot;GetDetailsByIMDBId&quot;&gt;http://movie.douban.com/subject/\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$2" output="&lt;url function=&quot;GetDetailsByIMDBId&quot;&gt;https://movie.douban.com/subject/\1&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
 			<expression noclean="1"/>
@@ -93,8 +93,8 @@
 	</GetDetails>	
 	<GetDetailsByIMDBId dest="5">
 		<RegExp input="$$6" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp conditional="trailer" input="$$1" output="&lt;trailer&gt;http://movie.douban.com/trailer/video_url?tid=\1&lt;/trailer&gt;" dest="6">
-				<expression>http://movie.douban.com/trailer/([0-9]+)</expression>
+			<RegExp conditional="trailer" input="$$1" output="&lt;trailer&gt;https://movie.douban.com/trailer/video_url?tid=\1&lt;/trailer&gt;" dest="6">
+				<expression>https://movie.douban.com/trailer/([0-9]+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="8">
 				<expression noclean="1">编剧&lt;/span&gt;:(.*?)&lt;/span&gt;</expression>
@@ -103,7 +103,7 @@
 				<expression repeat="yes">&lt;a href=[^&gt;]*&gt;(.*?)&lt;/a&gt;</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="8">
-				<expression>http://www.imdb.com/title/(tt[0-9]+)</expression>
+				<expression>https://www.imdb.com/title/(tt[0-9]+)</expression>
 			</RegExp>
 			<RegExp conditional="tmdbthumbs" input="$$8" output="&lt;chain function=&quot;GetTMDBThumbsByIdChain&quot;&gt;\1&lt;/chain&gt;" dest="6+">
 				<expression/>
@@ -116,7 +116,7 @@
 	</GetDetailsByIMDBId>
 	<GetPoster dest="5">
 		<RegExp input="$$6" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;thumb preview=&quot;\1thumb\2&quot;&gt;\1raw\2|Referer=http://movie.douban.com/&lt;/thumb&gt;" dest="6">
+			<RegExp input="$$1" output="&lt;thumb preview=&quot;\1thumb\2&quot;&gt;\1raw\2|Referer=https://movie.douban.com/&lt;/thumb&gt;" dest="6">
 				<expression repeat="yes" noclean="1,2">&lt;div class=&quot;cover&quot;&gt;\s*&lt;a href=&quot;https://movie.douban.com/photos/photo/[0-9]+/&quot;&gt;\s*&lt;img src=&quot;(https://[^/]+/view/photo/)thumb(/public/[^\.]+\.jpg)&quot; /&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -124,7 +124,7 @@
 	</GetPoster>
 	<GetFanart dest="5">
 		<RegExp input="$$6" output="&lt;details&gt;&lt;fanart&gt;\1&lt;/fanart&gt;&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;thumb preview=&quot;\1thumb\2&quot;&gt;\1raw\2|Referer=http://movie.douban.com/&lt;/thumb&gt;" dest="6">
+			<RegExp input="$$1" output="&lt;thumb preview=&quot;\1thumb\2&quot;&gt;\1raw\2|Referer=https://movie.douban.com/&lt;/thumb&gt;" dest="6">
 				<expression repeat="yes" noclean="1,2">&lt;div class=&quot;cover&quot;&gt;\s*&lt;a href=&quot;https://movie.douban.com/photos/photo/[0-9]+/&quot;&gt;\s*&lt;img src=&quot;(https://[^/]+/view/photo/)thumb(/public/[^\.]+\.jpg)&quot; /&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>

--- a/metadata.filmaffinity.com/filmaffinity.xml
+++ b/metadata.filmaffinity.com/filmaffinity.xml
@@ -3,7 +3,7 @@
 
 	<!--obtención de la url desde el fichero .nfo -->
 	<NfoUrl dest="3">
-		<RegExp conditional="!FAmobile" input="$$5" output="&lt;url&gt;http://www.filmaffinity.com/es/film\1.html\2&lt;/url&gt;" dest="3">
+		<RegExp conditional="!FAmobile" input="$$5" output="&lt;url&gt;https://www.filmaffinity.com/es/film\1.html\2&lt;/url&gt;" dest="3">
 			<RegExp input="$$1" output="\2;" dest="5">
 				<expression noclean="1">/(www|m).filmaffinity.com/[^/]+/[^0-9]+([0-9]+)</expression>
 			</RegExp>
@@ -12,7 +12,7 @@
 			</RegExp>
 			<expression noclean="1">([0-9]+);(.*)</expression>
 		</RegExp>
-		<RegExp conditional="FAmobile" input="$$5" output="&lt;url&gt;http://m.filmaffinity.com/es/movie.php?id=\1\2&lt;/url&gt;" dest="3">
+		<RegExp conditional="FAmobile" input="$$5" output="&lt;url&gt;https://m.filmaffinity.com/es/movie.php?id=\1\2&lt;/url&gt;" dest="3">
 			<RegExp input="$$1" output="\2;" dest="5">
 				<expression noclean="1">/(www|m).filmaffinity.com/[^/]+/[^0-9]+([0-9]+)</expression>
 			</RegExp>
@@ -26,7 +26,7 @@
 	<!-- búsqueda principal -->
 	<CreateSearchUrl SearchStringEncoding="UTF-8" dest="3">
 		<!-- búsqueda de filmaffinity usando título y año -->
-		<RegExp conditional="!GoogleAdvSearch" input="$$1" output="&lt;url&gt;http://www.filmaffinity.com/es/advsearch.php?stype[]=title&amp;fromyear=$$2&amp;toyear=$$2&amp;stext=\1&lt;/url&gt;" dest="3">
+		<RegExp conditional="!GoogleAdvSearch" input="$$1" output="&lt;url&gt;https://www.filmaffinity.com/es/advsearch.php?stype[]=title&amp;fromyear=$$2&amp;toyear=$$2&amp;stext=\1&lt;/url&gt;" dest="3">
 			<expression noclean="1" />
 		</RegExp>
 		<!-- búsqueda en filmaffinity a través de google -->
@@ -47,11 +47,11 @@
 				<expression repeat="yes">/film([0-9]+).html&amp;[^&gt;]+&gt;(.+?)( - [&lt;F].+?)?&lt;/a&gt;</expression>
 			</RegExp>
 			<!-- resultados de la web principal -->
-			<RegExp conditional="!FAmobile" input="$$5" output="\1&lt;url&gt;http://www.filmaffinity.com/es/film\2.html&lt;/url&gt;&lt;/entity&gt;" dest="5">
+			<RegExp conditional="!FAmobile" input="$$5" output="\1&lt;url&gt;https://www.filmaffinity.com/es/film\2.html&lt;/url&gt;&lt;/entity&gt;" dest="5">
 				<expression repeat="yes" noclean="1">(&lt;entity&gt;.+?([0-9]+)&lt;/id&gt;)&lt;/entity&gt;</expression>
 			</RegExp>
 			<!-- resultados de la web móvil -->
-			<RegExp conditional="FAmobile" input="$$5" output="\1&lt;url&gt;http://m.filmaffinity.com/es/movie.php?id=\2&lt;/url&gt;&lt;/entity&gt;" dest="5">
+			<RegExp conditional="FAmobile" input="$$5" output="\1&lt;url&gt;https://m.filmaffinity.com/es/movie.php?id=\2&lt;/url&gt;&lt;/entity&gt;" dest="5">
 				<expression repeat="yes" noclean="1">(&lt;entity&gt;.+?([0-9]+)&lt;/id&gt;)&lt;/entity&gt;</expression>
 			</RegExp>
 			<!-- en caso de que haya más de 10 páginas de resultados en FA asumimos un error en la búsqueda -->
@@ -222,11 +222,11 @@
 				<!-- descomponemos en palabras el título original y las unimos con "+" -->
 				<RegExp input="$$12" output="\1+" dest="9">
 					<!-- caracteres latinos UTF-8, números y aperturas de paréntesis -->
-					<!-- fuente: http://www.w3schools.com/charsets/ref_html_utf8.asp -->
+					<!-- fuente: https://www.w3schools.com/charsets/ref_html_utf8.asp -->
 					<expression repeat="yes">([\(a-zA-Z0-9&#192;-&#591;]+)</expression>
 				</RegExp>
 				<!-- búsqueda en imdb, sin el año -->
-				<RegExp conditional="!GoogleAdvSearch" input="$$9" output="http://www.imdb.com/xml/find?xml=1&amp;nr=1&amp;tt=on&amp;q=\1" dest="9">
+				<RegExp conditional="!GoogleAdvSearch" input="$$9" output="https://www.imdb.com/xml/find?xml=1&amp;nr=1&amp;tt=on&amp;q=\1" dest="9">
 					<!-- nos quedamos con el título original sólo hasta encontrar (o no) una apertura de paréntesis -->
 					<RegExp input="$$9" output="\1" dest="9">
 						<expression>([^\(]+)</expression>
@@ -262,17 +262,17 @@
 				<expression>HD-Trailers\(1080p\)</expression>
 			</RegExp>
 			<!-- trailer de filmaffinity -->
-			<RegExp conditional="EnableFATrailer" input="$$16" output="&lt;url function=&quot;GetFilmAffinityTrailer&quot;&gt;http://www.filmaffinity.com/es/movieTrailer.php?id=\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableFATrailer" input="$$16" output="&lt;url function=&quot;GetFilmAffinityTrailer&quot;&gt;https://www.filmaffinity.com/es/movieTrailer.php?id=\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 
 			<!-- descarga el poster principal de filmaffinity -->
-			<RegExp conditional="FirstFilmAffinityPoster" input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://pics.filmaffinity.com/\2&lt;/thumb&gt;" dest="5+">
-				<expression noclean="1">(href|src)=&quot;http://pics.filmaffinity.com/([^&quot;]+)</expression>
+			<RegExp conditional="FirstFilmAffinityPoster" input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://pics.filmaffinity.com/\2&lt;/thumb&gt;" dest="5+">
+				<expression noclean="1">(href|src)=&quot;https://pics.filmaffinity.com/([^&quot;]+)</expression>
 			</RegExp>
 			
 			<!-- descarga todos los posters que haya en filmaffinity -->
-			<RegExp conditional="EnableFilmAffinityPosters" input="$$16" output="&lt;url function=&quot;GetFilmAffinityPosters&quot;&gt;http://www.filmaffinity.com/es/filmimages.php?movie_id=\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableFilmAffinityPosters" input="$$16" output="&lt;url function=&quot;GetFilmAffinityPosters&quot;&gt;https://www.filmaffinity.com/es/filmimages.php?movie_id=\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 			
@@ -332,11 +332,11 @@
 				<expression noclean="1" />
 			</RegExp>
 			<!-- obtención del poster de trakt.tv -->
-			<RegExp conditional="EnableTraktPoster" input="$$6" output="&lt;url cache=&quot;trakttv-tt$$6.json&quot; function=&quot;GetTraktPoster&quot;&gt;http://api.trakt.tv/movie/summary.json/be64291aafbbbe62fdc4f3aa0edb4073/tt$$6&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableTraktPoster" input="$$6" output="&lt;url cache=&quot;trakttv-tt$$6.json&quot; function=&quot;GetTraktPoster&quot;&gt;https://api.trakt.tv/movie/summary.json/be64291aafbbbe62fdc4f3aa0edb4073/tt$$6&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 			<!-- obtención del poster de fanart.tv -->
-			<RegExp conditional="EnableFanartTvPoster" input="$$6" output="&lt;url cache=&quot;fanarttv-tt$$6.json&quot; function=&quot;GetFanartTvPoster&quot;&gt;http://webservice.fanart.tv/v3/movies/tt\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableFanartTvPoster" input="$$6" output="&lt;url cache=&quot;fanarttv-tt$$6.json&quot; function=&quot;GetFanartTvPoster&quot;&gt;https://webservice.fanart.tv/v3/movies/tt\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 			<!-- obtención de los posters de IMDB -->
@@ -349,11 +349,11 @@
 			</RegExp>
 			
 			<!-- obtención de los fanarts de trakt.tv -->
-			<RegExp conditional="EnableTraktFanArt" input="$$6" output="&lt;url cache=&quot;trakttv-tt$$6.json&quot; function=&quot;GetTraktFanart&quot;&gt;http://api.trakt.tv/movie/summary.json/be64291aafbbbe62fdc4f3aa0edb4073/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableTraktFanArt" input="$$6" output="&lt;url cache=&quot;trakttv-tt$$6.json&quot; function=&quot;GetTraktFanart&quot;&gt;https://api.trakt.tv/movie/summary.json/be64291aafbbbe62fdc4f3aa0edb4073/tt\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 			<!-- obtención de los fanarts de fanart.tv -->
-			<RegExp conditional="EnableFanartTvFanart" input="$$6" output="&lt;url cache=&quot;fanarttv-tt$$6.json&quot; function=&quot;GetFanartTvFanart&quot;&gt;http://webservice.fanart.tv/v3/movies/tt\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="EnableFanartTvFanart" input="$$6" output="&lt;url cache=&quot;fanarttv-tt$$6.json&quot; function=&quot;GetFanartTvFanart&quot;&gt;https://webservice.fanart.tv/v3/movies/tt\1?api_key=ed4b784f97227358b31ca4dd966a04f1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" />
 			</RegExp>
 			<!-- obtención de los fanarts de TMDB -->
@@ -413,7 +413,7 @@
 	<!-- función para la obtención de posters de filmaffinity -->
 	<GetFilmAffinityPosters dest="5">
 		<RegExp input="$$10" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://pics.filmaffinity.com/\1&lt;/thumb&gt;" dest="10">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://pics.filmaffinity.com/\1&lt;/thumb&gt;" dest="10">
 				<expression repeat="yes" noclean="1">pics.filmaffinity.com/([^&quot;]+)&quot; title=&quot;[^&quot;]+?Poster</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -423,14 +423,14 @@
 	<!-- función para la obtención de poster de trakt.tv -->
 	<GetTraktPoster dest="5">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;thumb aspect=&quot;poster&quot;&gt;\1&lt;/thumb&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">&quot;poster&quot;:&quot;(http://[^&quot;]+)</expression>
+			<expression noclean="1">&quot;poster&quot;:&quot;(https://[^&quot;]+)</expression>
 		</RegExp>
 	</GetTraktPoster>
 	
 	<!-- función para la obtención de fanart de trakt.tv -->
 	<GetTraktFanart dest="5">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;fanart&gt;&lt;thumb&gt;\1&lt;/thumb&gt;&lt;/fanart&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">&quot;fanart&quot;:&quot;(http://[^&quot;]+)</expression>
+			<expression noclean="1">&quot;fanart&quot;:&quot;(https://[^&quot;]+)</expression>
 		</RegExp>
 	</GetTraktFanart>
 	

--- a/metadata.filmweb.pl/filmweb.xml
+++ b/metadata.filmweb.pl/filmweb.xml
@@ -198,7 +198,7 @@
             </RegExp>
             
             <!-- TMDbSearch - Wyszukuje TMDbID na TMDb !-->
-            <RegExp input="$$16" output="&lt;url function=&quot;TMDbSearch&quot;&gt;http://api.themoviedb.org/3/search/movie?api_key=1009b5cde25c7b0692d51a7db6e49cbd&amp;query=\1&lt;/url&gt;" dest="5+">
+            <RegExp input="$$16" output="&lt;url function=&quot;TMDbSearch&quot;&gt;https://api.themoviedb.org/3/search/movie?api_key=1009b5cde25c7b0692d51a7db6e49cbd&amp;query=\1&lt;/url&gt;" dest="5+">
                 <expression encode="1" />
             </RegExp>
             
@@ -215,7 +215,7 @@
     <TMDbSearch clearbuffers="no" dest="3">
         <RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
             <!-- Zapisuje TMDb ID i jeśli istnieje wyszukuje IMDb ID !-->
-            <RegExp input="$$6" output="&lt;url cache=&quot;tmdb-en-\1.json&quot; function=&quot;TMDbIDtoIMDbID&quot;&gt;http://api.themoviedb.org/3/movie/\1?api_key=1009b5cde25c7b0692d51a7db6e49cbd&lt;/url&gt;" dest="5">
+            <RegExp input="$$6" output="&lt;url cache=&quot;tmdb-en-\1.json&quot; function=&quot;TMDbIDtoIMDbID&quot;&gt;https://api.themoviedb.org/3/movie/\1?api_key=1009b5cde25c7b0692d51a7db6e49cbd&lt;/url&gt;" dest="5">
                 <!-- Pierwsze znalezione ID !-->
                 <RegExp input="$$1" output="\1" dest="6">
                     <expression clear="yes">&quot;id&quot;:([0-9]+),&quot;</expression>
@@ -248,7 +248,7 @@
             <RegExp input="$$16" output="\1" dest="14">
                 <expression encode="1" />
             </RegExp>
-            <RegExp input="$$18" output="&lt;url function=&quot;GoogleSearch&quot;&gt;http://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=$$14+site:imdb.com&amp;hl=pl&lt;/url&gt;" dest="5">
+            <RegExp input="$$18" output="&lt;url function=&quot;GoogleSearch&quot;&gt;https://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=$$14+site:imdb.com&amp;hl=pl&lt;/url&gt;" dest="5">
                 <expression>^$</expression>
             </RegExp>
             <expression noclean="1" />
@@ -264,7 +264,7 @@
             </RegExp>
             
             <!-- Jeśli na TMDb nie istnieje IMDb ID wyszukuje na google !-->
-            <RegExp input="$$5" output="&lt;url function=&quot;GoogleSearch&quot;&gt;http://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=$$14+site:imdb.com&amp;hl=pl&lt;/url&gt;" dest="5">
+            <RegExp input="$$5" output="&lt;url function=&quot;GoogleSearch&quot;&gt;https://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=$$14+site:imdb.com&amp;hl=pl&lt;/url&gt;" dest="5">
                 <expression>^$</expression>
             </RegExp>
             <expression noclean="1" />
@@ -447,7 +447,7 @@
                 <expression>source src=&quot;([^&quot;]+)&quot; type=.video/quicktime</expression>
             </RegExp>
             <RegExp input="$$5" output="plugin://plugin.video.youtube/?action=play_video&videoid=\1" dest="4">
-                <expression>&quot;http://www.youtube.com/v/([^&quot;]+)&quot;</expression>
+                <expression>&quot;https://www.youtube.com/v/([^&quot;]+)&quot;</expression>
             </RegExp>
             <expression />
         </RegExp>

--- a/metadata.kinopoisk.ru/kinopoisk.xml
+++ b/metadata.kinopoisk.ru/kinopoisk.xml
@@ -2,12 +2,12 @@
 <scraper date="2010-02-23" framework="1.1">
 	<NfoUrl dest="3">
 		<RegExp input="$$1" output="&lt;url&gt;\1|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&lt;/url&gt;" dest="3">
-			<expression noclean="1">(http://www\.kinopoisk\.ru/level/1/film/[0-9]*/)</expression>
+			<expression noclean="1">(https://www\.kinopoisk\.ru/level/1/film/[0-9]*/)</expression>
 		</RegExp>
 	</NfoUrl>
 	<!-- Формируем поисковый URl -->
 	<CreateSearchUrl SearchStringEncoding="CP1251" dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://s.kinopoisk.ru/index.php?level=7&amp;from=forma&amp;result=adv&amp;m_act%5Bfrom%5D=forma&amp;m_act%5Bwhat%5D=content&amp;m_act%5Bfind%5D=\1&amp;m_act%5Byear%5D=$$2|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://s.kinopoisk.ru/index.php?level=7&amp;from=forma&amp;result=adv&amp;m_act%5Bfrom%5D=forma&amp;m_act%5Bwhat%5D=content&amp;m_act%5Bfind%5D=\1&amp;m_act%5Byear%5D=$$2|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;" dest="3">
 			<expression noclean="1"/>
 		</RegExp>
 	</CreateSearchUrl>
@@ -34,16 +34,16 @@
 				<RegExp input="$$1" output="&lt;year&gt;\1&lt;/year&gt;" dest="7+">
 					<expression>&lt;a href="/level/10/m_act%5Byear%5D/(\d+)/"</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;url&gt;http://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;" dest="7+">
+				<RegExp input="$$1" output="&lt;url&gt;https://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;" dest="7+">
 					<expression>&lt;a href="/level/19/film/(\d+)/"&gt;</expression>
 				</RegExp>
 				<expression noclean="1" />
 			</RegExp>
 			<!--Код если найдено несколько вариантов-->
-			<RegExp conditional="!search_originaltitle" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url&gt;http://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+			<RegExp conditional="!search_originaltitle" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url&gt;https://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;&lt;/entity&gt;" dest="5+">
 				<expression repeat="yes">&lt;p class="name"&gt;&lt;a href="/level/1/film/(\d+)/sr/1/"&gt;(.+?)&lt;/a&gt;[^&gt;]*?class="year"&gt;(\d+)&lt;</expression>
 			</RegExp>
-			<RegExp conditional="search_originaltitle" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2 [\4]&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url&gt;http://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+			<RegExp conditional="search_originaltitle" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2 [\4]&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url&gt;https://www.kinopoisk.ru/level/1/film/\1/sr/1/|User-Agent=Mozilla%2F5.0%20(X11%3B%20U%3B%20Linux%20x86_64%3B%20rv%3A2.0.1)%20Gecko%2F20100101%20Firefox%2F4.0.1&amp;Accept-Language=ru-ru,ru%3Bq=0.8,en-us%3Bq=0.5,en%3Bq=0.3&lt;/url&gt;&lt;/entity&gt;" dest="5+">
 				<expression repeat="yes">&lt;p class="name"&gt;&lt;a href="/level/1/film/(\d+)/sr/1/"&gt;(.+?)&lt;/a&gt;[^&gt;]*?class="year"&gt;(\d+)&lt;.*?class="gray"&gt;(?:(?:\d+ мин)|)(.*?)(?:(?:, \d+ мин)|)&lt;</expression>
 			</RegExp>
 			<!-- fix html entities from titles-->
@@ -117,7 +117,7 @@
 			</RegExp>
 			<!--COUNTRY-->
 			<RegExp input="$$1" output="&lt;country&gt;\1&lt;/country&gt;" dest="5+">
-				<expression repeat="yes">&lt;a href="/level/10/m_act%5Bcountry%5D/.+?/"&gt;&lt;img src="http://st.kinopoisk.ru/images/flags/flag.*?alt="(.*?)"</expression>
+				<expression repeat="yes">&lt;a href="/level/10/m_act%5Bcountry%5D/.+?/"&gt;&lt;img src="https://st.kinopoisk.ru/images/flags/flag.*?alt="(.*?)"</expression>
 			</RegExp>
 			<!--YEAR-->
 			<RegExp input="$$1" output="\1" dest="13">
@@ -204,41 +204,41 @@
 				<expression>(.*)&amp;mdash;</expression>
 			</RegExp>
 			<!--STUDIO-->
-			<RegExp input="$$1" output="&lt;url function=&quot;STUDIOS&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;STUDIOS&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="5+">
 				<expression>"(/level/91/film/\d+/)"</expression>
 			</RegExp>
 			<!--PEOPLE-->
-			<RegExp input="$$1" output="&lt;url function=&quot;PEOPLE&quot;&gt;http://www.kinopoisk.ru/level/19/film/\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url function=&quot;PEOPLE&quot;&gt;https://www.kinopoisk.ru/level/19/film/\1&lt;/url&gt;" dest="5+">
 				<expression>href="/level/19/film/(\d+)/"</expression>
 			</RegExp>
 			<!--POSTERS-->
-			<RegExp conditional="posters_from_kinopoisk" input="$$1" output="&lt;url function=&quot;GMP&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="posters_from_kinopoisk" input="$$1" output="&lt;url function=&quot;GMP&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="5+">
 				<expression>href="(/level/17/film/([0-9]+)/)"</expression>
 			</RegExp>
 			<!--TRAILER-->
-			<RegExp conditional="download_trailer" input="$$1" output="&lt;url function=&quot;GetTrailers&quot;&gt;http://www.kinopoisk.ru/level/16/film/\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="download_trailer" input="$$1" output="&lt;url function=&quot;GetTrailers&quot;&gt;https://www.kinopoisk.ru/level/16/film/\1&lt;/url&gt;" dest="5+">
 				<expression>&lt;a href="/level/16/film/(\d+)/</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
 	</GetDetails>
 	<GetPoster dest="4">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;thumb preview=&quot;http://st.kinopoisk.ru/images/poster/sm_\2.jpg&quot;&gt;http://st.kinopoisk.ru/\1&lt;/thumb&gt;&lt;/details&gt;" dest="4">
-		<expression repeat="no" noclean="1">&lt;img style="cursor: pointer;" id="image" src="http://st.kinopoisk.ru/([^"]+?-(\d+).jpg)"</expression>
+		<RegExp input="$$1" output="&lt;details&gt;&lt;thumb preview=&quot;https://st.kinopoisk.ru/images/poster/sm_\2.jpg&quot;&gt;https://st.kinopoisk.ru/\1&lt;/thumb&gt;&lt;/details&gt;" dest="4">
+		<expression repeat="no" noclean="1">&lt;img style="cursor: pointer;" id="image" src="https://st.kinopoisk.ru/([^"]+?-(\d+).jpg)"</expression>
 		</RegExp>
 	</GetPoster>
 	<GMP dest="4">
 		<RegExp input="$$8" output="&lt;details&gt;\1&lt;/details&gt;" dest="4+">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
-				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img class="new" src="http://st.[^"]+" width</expression>
+			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
+				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img class="new" src="https://st.[^"]+" width</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
-				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img  src="http://st.[^"]+" width</expression>
+			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
+				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img  src="https://st.[^"]+" width</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="7">
 				<expression noclean="1">&lt;div class="navigator"&gt;(.*?)&lt;/div&gt;</expression>
 			</RegExp>
-			<RegExp input="$$7" output="&lt;url function=&quot;GMP_SINGLE&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
+			<RegExp input="$$7" output="&lt;url function=&quot;GMP_SINGLE&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
 				<expression repeat="yes" noclean="1">&lt;li &gt;&lt;a href="(/level/17/film/\d+/page/\d+/)"&gt;\d+&lt;/a&gt;&lt;/li&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -246,8 +246,8 @@
 	</GMP>
 	<GMP_SINGLE dest="4">
 		<RegExp input="$$8" output="&lt;details&gt;\1&lt;/details&gt;" dest="4+">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;http://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
-				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img  src="http://st.[^"]+" width</expression>
+			<RegExp input="$$1" output="&lt;url function=&quot;GetPoster&quot;&gt;https://www.kinopoisk.ru\1&lt;/url&gt;" dest="8+">
+				<expression repeat="yes" noclean="1">&lt;a href="(/picture/[0-9]+/)"&gt;&lt;img  src="https://st.[^"]+" width</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -262,7 +262,7 @@
 		<RegExp input="" output="&lt;!-- ролик --&gt;([^!]*?&lt;div style=&quot;position: relative&quot;&gt;[^&lt;]*(?:&lt;img[^&gt;]*(flag-2.gif))*[^!]*?class=&quot;all&quot;&gt;([^&lt;]+)[^!]*)&lt;!-- /ролик --&gt;" dest="10">
 			<expression/>
 		</RegExp>
-		<RegExp input="" output="&lt;td width=20&gt;(?:&lt;img src=&quot;http://st.kinopoisk.ru/images/icon-(hd)2.gif&quot;)*[^&lt;]*&lt;/td[^&lt;]*&lt;td[^&lt;]*&lt;a href=&quot;(?:.*?)&amp;type=trailer&amp;link=([^&quot;]+)&quot; class=&quot;continue&quot;&gt;(?:&lt;b&gt;)*(.+?)(?:&lt;/b&gt;)*&lt;/a&gt;" dest="11">
+		<RegExp input="" output="&lt;td width=20&gt;(?:&lt;img src=&quot;https://st.kinopoisk.ru/images/icon-(hd)2.gif&quot;)*[^&lt;]*&lt;/td[^&lt;]*&lt;td[^&lt;]*&lt;a href=&quot;(?:.*?)&amp;type=trailer&amp;link=([^&quot;]+)&quot; class=&quot;continue&quot;&gt;(?:&lt;b&gt;)*(.+?)(?:&lt;/b&gt;)*&lt;/a&gt;" dest="11">
 			<expression/>
 		</RegExp>
 		<!-- Собираем всё видео -->
@@ -379,14 +379,14 @@
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression clear="yes" noclean="1">&lt;tr&gt;&lt;td colspan=3&gt;&lt;a name="actor"&gt;&lt;/td&gt;&lt;/tr&gt;.+?&lt;/table&gt;(.*?)&lt;table</expression>
 			</RegExp>
-			<RegExp conditional="!rus_actor_names" input="$$9" output="&lt;n&gt;\2&lt;r&gt;\3&lt;t&gt;http://st.kinopoisk.ru/images/actor/\1&lt;/e&gt;" dest="9">
+			<RegExp conditional="!rus_actor_names" input="$$9" output="&lt;n&gt;\2&lt;r&gt;\3&lt;t&gt;https://st.kinopoisk.ru/images/actor/\1&lt;/e&gt;" dest="9">
 				<expression repeat="yes" trim="3">title="/images/(?:sm_actor/([0-9]+.jpg)|no-poster.gif)" alt=.+?&lt;a href="/level/4/people/\d+/"&gt;(.*?)&lt;/a&gt;.+?"role"&gt;... ([^&lt;]+)</expression>
 			</RegExp>
-			<RegExp conditional="rus_actor_names" input="$$9" output="&lt;n&gt;\2&lt;r&gt;\3&lt;t&gt;http://st.kinopoisk.ru/images/actor/\1&lt;/e&gt;" dest="9">
+			<RegExp conditional="rus_actor_names" input="$$9" output="&lt;n&gt;\2&lt;r&gt;\3&lt;t&gt;https://st.kinopoisk.ru/images/actor/\1&lt;/e&gt;" dest="9">
 				<expression repeat="yes" trim="3">title="/images/(?:sm_actor/([0-9]+.jpg)|no-poster.gif)" alt=.+?&lt;a href="/level/4/people/\d+/"&gt;([а-яА-Я][^&lt;]*)&lt;/a&gt;.*?"role"&gt;... ([^&lt;]+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;thumb&gt;\3&lt;/thumb&gt;&lt;/actor&gt;" dest="7">
-				<expression repeat="yes" trim="3">&lt;n&gt;([^&lt;]+)&lt;r&gt;(?:играет |)([^&lt;]+)&lt;t&gt;(?:(http://st.kinopoisk.ru/images/actor/[0-9]+.jpg)&lt;/e&gt;|http://st.kinopoisk.ru/images/actor/&lt;/e&gt;)</expression>
+				<expression repeat="yes" trim="3">&lt;n&gt;([^&lt;]+)&lt;r&gt;(?:играет |)([^&lt;]+)&lt;t&gt;(?:(https://st.kinopoisk.ru/images/actor/[0-9]+.jpg)&lt;/e&gt;|https://st.kinopoisk.ru/images/actor/&lt;/e&gt;)</expression>
 			</RegExp>
 			<!-- убираем &nbsp; из ролей актёров -->
 			<RegExp input="$$7" output="\1&amp;nbsp;" dest="7">
@@ -472,7 +472,7 @@
 				<RegExp input="none" output="$$15:::$$18:::$$19" dest="20">
 					<expression/>
 				</RegExp>
-				<RegExp input="$$20" output="&lt;url function=&quot;GetIMDBIDSecondTry&quot;&gt;http://www.imdb.com/search/title?num_votes=\1,&amp;release_date=\2,\2&amp;title=\3&lt;/url&gt;" dest="6">
+				<RegExp input="$$20" output="&lt;url function=&quot;GetIMDBIDSecondTry&quot;&gt;https://www.imdb.com/search/title?num_votes=\1,&amp;release_date=\2,\2&amp;title=\3&lt;/url&gt;" dest="6">
 					<expression encode="3">(\d+):::(\d+):::(.+)</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -530,7 +530,7 @@
 		<RegExp input="none" output="" dest="4">
 			<expression/>
 		</RegExp>
-		<RegExp input="$$20" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url function=&quot;GetIMDBIDFromGoogle&quot;&gt;http://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=\3+(\2)+site%3Aimdb.com&lt;/url&gt;&lt;/details&gt;" dest="4">
+		<RegExp input="$$20" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url function=&quot;GetIMDBIDFromGoogle&quot;&gt;https://ajax.googleapis.com/ajax/services/search/web?v=1.0&amp;q=\3+(\2)+site%3Aimdb.com&lt;/url&gt;&lt;/details&gt;" dest="4">
 			<RegExp conditional="use_world_premier" input="none" output="$$13" dest="18">
 				<expression/>
 			</RegExp>
@@ -552,7 +552,7 @@
 				<expression/>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;chain function=&quot;GetIMDBIDData&quot;&gt;\1&lt;/chain&gt;" dest="2">
-				<expression>http://www.imdb.com/title/(tt\d+)/</expression>
+				<expression>https://www.imdb.com/title/(tt\d+)/</expression>
 			</RegExp>
 			<expression/>
 		</RegExp>
@@ -583,7 +583,7 @@
 			<expression/>
 		</RegExp>
 		<RegExp input="$$8" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp conditional="!google_search" input="$$20" output="&lt;url function=&quot;GetIMDBIDFirstTry&quot;&gt;http://www.imdb.com/search/title?num_votes=\1,&amp;release_date=\2,\2&amp;title=\3&lt;/url&gt;" dest="6">
+			<RegExp conditional="!google_search" input="$$20" output="&lt;url function=&quot;GetIMDBIDFirstTry&quot;&gt;https://www.imdb.com/search/title?num_votes=\1,&amp;release_date=\2,\2&amp;title=\3&lt;/url&gt;" dest="6">
 				<expression noclean="1" encode="3">(\d+):::(\d+):::(.+)</expression>
 			</RegExp>
 			<RegExp conditional="google_search" input="$$20" output="&lt;chain function=&quot;GetIMDBIDGoogleFallback&quot;&gt;XBMC need some data&lt;/chain&gt;" dest="6">

--- a/metadata.movie.animenewsnetwork.com/ann-movies.xml
+++ b/metadata.movie.animenewsnetwork.com/ann-movies.xml
@@ -2,13 +2,13 @@
 <scraper framework="1.1" date="2010-03-26">
 	<include>common/tmdb.xml</include>
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;\1.html&quot;&gt;http://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;\1.html&quot;&gt;https://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
 			<expression>animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
 
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$6" output="&lt;url&gt;http://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=web&amp;xmltype=attributebased&amp;Query=\1+movie+-&quot;number+of+episodes&quot;+site%3Aanimenewsnetwork.com%2Fencyclopedia&lt;/url&gt;" dest="3">
+		<RegExp input="$$6" output="&lt;url&gt;https://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=web&amp;xmltype=attributebased&amp;Query=\1+movie+-&quot;number+of+episodes&quot;+site%3Aanimenewsnetwork.com%2Fencyclopedia&lt;/url&gt;" dest="3">
 			<RegExp input="$$1" output="$$1%20%2dEND" dest="5">
 				<expression/>
 			</RegExp>
@@ -21,8 +21,8 @@
 
 	<GetSearchResults dest="3">
 		<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results sorted=&quot;Yes&quot;&gt;\1&lt;/results&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url cache=&quot;\2.html&quot;&gt;http://www.animenewsnetwork.com/encyclopedia/anime.php?id=\2&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes">&lt;web:WebResult Title=&quot;([^&gt;&quot;]+?)&quot; [^&gt;]* Url=&quot;http://www.animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]+?)&quot; [^&gt;]*&gt;</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url cache=&quot;\2.html&quot;&gt;https://www.animenewsnetwork.com/encyclopedia/anime.php?id=\2&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<expression repeat="yes">&lt;web:WebResult Title=&quot;([^&gt;&quot;]+?)&quot; [^&gt;]* Url=&quot;https://www.animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]+?)&quot; [^&gt;]*&gt;</expression>
 			</RegExp>
 			<expression clear="yes" noclean="1"/>
 		</RegExp>
@@ -121,7 +121,7 @@
 				<expression repeat="yes">&lt;actor&gt;&lt;name&gt;(.*?)&lt;/name&gt;&lt;role&gt;(.*?)&lt;/role&gt;&lt;/actor&gt;</expression>
 			</RegExp>
 
-			<RegExp conditional="fanart" input="$$7" output="&lt;url cache=&quot;$$2-tmdb-search.xml&quot; function=&quot;GetFanart&quot;&gt;http://api.themoviedb.org/2.1/Movie.search/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="fanart" input="$$7" output="&lt;url cache=&quot;$$2-tmdb-search.xml&quot; function=&quot;GetFanart&quot;&gt;https://api.themoviedb.org/2.1/Movie.search/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="6">
 					<expression trim="1">page_header&quot;&gt;([^\(&lt;]*)</expression>
 				</RegExp>
@@ -131,10 +131,10 @@
 				<expression noclean="1"/>
 			</RegExp>
 
-			<RegExp conditional="!poster" input="$$1" output="&lt;thumb&gt;http://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp conditional="!poster" input="$$1" output="&lt;thumb&gt;https://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;" dest="5+">
 				<expression>/thumbnails/fit200x200/encyc/([^']*)</expression>
 			</RegExp>
-			<RegExp conditional="poster" input="$$7" output="&lt;url cache=&quot;$$2-tmdb-search.xml&quot; function=&quot;GetPoster&quot;&gt;http://api.themoviedb.org/2.1/Movie.search/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5+">
+			<RegExp conditional="poster" input="$$7" output="&lt;url cache=&quot;$$2-tmdb-search.xml&quot; function=&quot;GetPoster&quot;&gt;https://api.themoviedb.org/2.1/Movie.search/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="6">
 					<expression trim="1">page_header&quot;&gt;([^\(&lt;]*)</expression>
 				</RegExp>
@@ -152,19 +152,19 @@
 	</GetDetails>
 
 	<GetFanart dest="3">
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;tmdb-\1.xml&quot; function=&quot;GetTMDBFanartById&quot;&gt;http://api.themoviedb.org/2.1/Movie.getInfo/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;tmdb-\1.xml&quot; function=&quot;GetTMDBFanartById&quot;&gt;https://api.themoviedb.org/2.1/Movie.getInfo/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 		</RegExp>
 	</GetFanart>
 
 	<GetPoster dest="3">
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;tmdb-\1.xml&quot; function=&quot;GetTMDBThumbsById&quot;&gt;http://api.themoviedb.org/2.1/Movie.getInfo/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;tmdb-\1.xml&quot; function=&quot;GetTMDBThumbsById&quot;&gt;https://api.themoviedb.org/2.1/Movie.getInfo/en/xml/57983e31fb435df4df77afb854740ea9/\1&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 		</RegExp>
 	</GetPoster>
 
 	<GetANNThumbnail dest="3">
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;thumb&gt;http://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;thumb&gt;https://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;&lt;/details&gt;" dest="3">
 			<expression>/thumbnails/fit200x200/encyc/([^']*)</expression>
 		</RegExp>
 	</GetANNThumbnail>

--- a/metadata.movieplayer.it/movieplayer.xml
+++ b/metadata.movieplayer.it/movieplayer.xml
@@ -11,7 +11,7 @@
 			</RegExp-->
 			<expression noclean="1" />
 		</RegExp>
-		<RegExp conditional="Bing" input="$$1" output="&lt;url&gt;http://it.bing.com/search?q=&quot;\1$$4&quot;+site%3Amovieplayer.it%2Ffilm%2F+-site%3Amovieplayer.it%2Ffilm%2Fnews%2F+-site%3Amovieplayer.it%2Ffilm%2Farticoli%2F+-site%3Amovieplayer.it%2Ffilm%2Fprossimamente%2F+-site%3Amovieplayer.it%2Ffilm%2Fboxoffice%2F&amp;count=$INFO[count]&lt;/url&gt;" dest="3">
+		<RegExp conditional="Bing" input="$$1" output="&lt;url&gt;https://it.bing.com/search?q=&quot;\1$$4&quot;+site%3Amovieplayer.it%2Ffilm%2F+-site%3Amovieplayer.it%2Ffilm%2Fnews%2F+-site%3Amovieplayer.it%2Ffilm%2Farticoli%2F+-site%3Amovieplayer.it%2Ffilm%2Fprossimamente%2F+-site%3Amovieplayer.it%2Ffilm%2Fboxoffice%2F&amp;count=$INFO[count]&lt;/url&gt;" dest="3">
 			<RegExp conditional="Year" input="$$2" output="%20(film+\1)" dest="4">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
@@ -87,7 +87,7 @@
 			</RegExp>
 
 			<!--IMDB details-->
-			<RegExp input="$$9" output="&lt;url cache=&quot;IMDB_Search.html&quot; function=&quot;IMDBChains&quot;&gt;http://akas.imdb.com/find?q=\1&amp;s=tt&lt;/url&gt;" dest="13+">
+			<RegExp input="$$9" output="&lt;url cache=&quot;IMDB_Search.html&quot; function=&quot;IMDBChains&quot;&gt;https://www.imdb.com/find?q=\1&amp;s=tt&lt;/url&gt;" dest="13+">
 				<RegExp input="$$13" output="\1" dest="9">
 					<expression clear="yes" noclean="1" encode="1">&lt;originaltitle&gt;([^/"]*)&lt;/originaltitle&gt;</expression>
 				</RegExp>

--- a/metadata.mymovies.it/mymovies.xml
+++ b/metadata.mymovies.it/mymovies.xml
@@ -13,7 +13,7 @@
 	</NfoUrl>
 
 	<CreateSearchUrl dest="3">
-		<RegExp conditional="google" input="$$1" output="&lt;url&gt;http://www.google.it/search?q=\1$$4+site:mymovies.it|User-Agent=Mozilla/5.0 (X11; Linux x86_64; rv:7.0.1) Gecko/20100101 Firefox/7.0.1&lt;/url&gt;" dest="3">
+		<RegExp conditional="google" input="$$1" output="&lt;url&gt;https://www.google.it/search?q=\1$$4+site:mymovies.it|User-Agent=Mozilla/5.0 (X11; Linux x86_64; rv:7.0.1) Gecko/20100101 Firefox/7.0.1&lt;/url&gt;" dest="3">
 			<!-- Add film year, stored in $$2 for default by xbmc -->
 			<RegExp input="$$2" output="%20(\1)" dest="4">
 				<expression clear="yes">(.+)</expression>
@@ -200,12 +200,12 @@
 			</RegExp>
 			
 			<!--MPAA, studio, ratings... from IMDB -->
-            <RegExp conditional="imdb" input="$$5" output="&lt;url cache=&quot;imdb-aka-result.html&quot; function=&quot;GetIMDBInfoByTitle&quot;&gt;http://akas.imdb.com/find?q=\1&amp;s=tt|accept-language=it-it&lt;/url&gt;" dest="5+">
+            <RegExp conditional="imdb" input="$$5" output="&lt;url cache=&quot;imdb-aka-result.html&quot; function=&quot;GetIMDBInfoByTitle&quot;&gt;https://www.imdb.com/find?q=\1&amp;s=tt|accept-language=it-it&lt;/url&gt;" dest="5+">
                 <expression encode="1">&lt;title&gt;([^&lt;]+)&lt;/title&gt;</expression>
             </RegExp>
 
 			<!-- Tmdb Backdrops from IMDB -->
-            <RegExp conditional="imdb" input="$$5" output="&lt;url cache=&quot;imdb-aka-result.html&quot; function=&quot;GetTMDBFanartByTitle&quot;&gt;http://akas.imdb.com/find?q=\1&amp;s=tt|accept-language=it-it&lt;/url&gt;" dest="5+">
+            <RegExp conditional="imdb" input="$$5" output="&lt;url cache=&quot;imdb-aka-result.html&quot; function=&quot;GetTMDBFanartByTitle&quot;&gt;https://www.imdb.com/find?q=\1&amp;s=tt|accept-language=it-it&lt;/url&gt;" dest="5+">
                 <expression encode="1">&lt;title&gt;([^&lt;]+)&lt;/title&gt;</expression>
             </RegExp>
 

--- a/metadata.port.hu/porthu.xml
+++ b/metadata.port.hu/porthu.xml
@@ -84,7 +84,7 @@
 			<!--Call GetIMDBDetails function-->
 			<RegExp input="$$10" output="\1" dest="5+">
 				<!--Create imdb URL based on the fetched imdb ID-->
-				<RegExp input="$$9" output="&lt;url cache=&quot;tt\1-main.html&quot; function=&quot;GetIMDBDetails&quot;&gt;http://akas.imdb.com/title/tt\1/|accept-language=en-us&lt;/url&gt;" dest="10">
+				<RegExp input="$$9" output="&lt;url cache=&quot;tt\1-main.html&quot; function=&quot;GetIMDBDetails&quot;&gt;https://www.imdb.com/title/tt\1/|accept-language=en-us&lt;/url&gt;" dest="10">
 					<expression />
 				</RegExp>
 				<expression noclean="1" />

--- a/metadata.themoviedb.org/tmdb.xml
+++ b/metadata.themoviedb.org/tmdb.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2012-01-16">
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://api.tmdb.org/3/search/movie?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;year=$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://api.tmdb.org/3/search/movie?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;year=$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
 			<RegExp input="$$2" output="\1" dest="4">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
@@ -9,25 +9,25 @@
 		</RegExp>
 	</CreateSearchUrl>
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression clear="yes" noclean="1">(themoviedb.org/movie/)([0-9]*)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[language]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[language]-tt\1.json&quot;&gt;https://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>imdb....?/title/tt([0-9]+)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[language]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[language]-tt\1.json&quot;&gt;https://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>imdb....?/Title\?t{0,2}([0-9]+)</expression>
 		</RegExp>
 	</NfoUrl>
 	<GetSearchResults dest="8">
 		<RegExp input="$$3" output="&lt;results&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3">
 				<expression repeat="yes">&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;[^&quot;]*&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;title&quot;:&quot;([^&quot;]*)&quot;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3+">
 				<expression repeat="yes">&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="3+">
 				<expression repeat="yes">&quot;release_date&quot;:null.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -59,7 +59,7 @@
 			<RegExp input="$$1" output="\1" dest="10">
 				<expression clear="yes" noclean="1">&quot;runtime&quot;:([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$10" output="&lt;url function=&quot;ParseFallbackTMDBRuntime&quot; cache=&quot;tmdb-en-$$2.json&quot;&gt;http://api.tmdb.org/3/movie/$$2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;url function=&quot;ParseFallbackTMDBRuntime&quot; cache=&quot;tmdb-en-$$2.json&quot;&gt;https://api.tmdb.org/3/movie/$$2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="5+">
 				<expression>^$</expression>
 			</RegExp>
 			<RegExp input="$$10" output="&lt;runtime&gt;\1&lt;/runtime&gt;" dest="5+">

--- a/metadata.thexem.de/xem.xml
+++ b/metadata.thexem.de/xem.xml
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <scraper framework="1.1" date="2012-06-17">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
-			<expression>http://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
+		<RegExp input="$$1" output="&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
+			<expression>https://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;http://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;https://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
 			<expression>imdb....?/title/tt([0-9]*)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;http://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;https://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
 			<expression>imdb....?/Title\?([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
 
 	<GetTVDBId dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 	</GetTVDBId>
@@ -28,7 +28,7 @@
 	</EpisodeGuideUrl>
 
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;cache-\1$$4.xml&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;cache-\1$$4.xml&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
 			<RegExp input="$$2" output="%20(\1)" dest="4">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
@@ -38,7 +38,7 @@
 
 	<GetSearchResults dest="1">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="1">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-\2.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/\2.zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-\2.xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/\2.zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
 				<expression repeat="yes">&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;[^&lt;]*&lt;language&gt;([^&lt;]*)&lt;/language&gt;[^&lt;]*&lt;SeriesName&gt;([^&lt;]*)&lt;/SeriesName&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -51,7 +51,7 @@
 	<GetEpisodeList dest="7">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="7">
 			<RegExp input="$$3" output="\2" dest="10">
-				<expression>http://(?:www\.)thetvdb.com/api/(.+)/series/([0-9]*)/all/(.+).zip</expression>
+				<expression>https://(?:www\.)thetvdb.com/api/(.+)/series/([0-9]*)/all/(.+).zip</expression>
 			</RegExp>
 			<!-- insert xem listing -->
 			<RegExp input="$$2" output="\1" dest="2">
@@ -60,20 +60,20 @@
 			<RegExp input="$$2" output="\1|" dest="2">
 				<expression repeat="yes" clear="yes">(\{.*?\})\}</expression>
 			</RegExp>
-			<RegExp conditional="!absolutenumber" input="$$2" output="&lt;episode&gt;&lt;url&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/default/\4/\5/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\2&lt;/epnum&gt;&lt;season&gt;\1&lt;/season&gt;&lt;/episode&gt;" dest="4">
+			<RegExp conditional="!absolutenumber" input="$$2" output="&lt;episode&gt;&lt;url&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/default/\4/\5/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\2&lt;/epnum&gt;&lt;season&gt;\1&lt;/season&gt;&lt;/episode&gt;" dest="4">
 				<expression repeat="yes" clear="no">&quot;$INFO[listing]&quot;:{&quot;season&quot;:([0-9]+),&quot;episode&quot;:([0-9]+),&quot;absolute&quot;:([0-9]+)[^|]*?&quot;tvdb&quot;:{&quot;season&quot;:([0-9]+),&quot;episode&quot;:([0-9]+),&quot;absolute&quot;:([0-9]+)</expression>
 			</RegExp>
-			<RegExp conditional="absolutenumber" input="$$2" output="&lt;episode&gt;&lt;url&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\6/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="4">
+			<RegExp conditional="absolutenumber" input="$$2" output="&lt;episode&gt;&lt;url&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\6/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="4">
 				<expression repeat="yes" clear="no">&quot;$INFO[listing]&quot;:{&quot;season&quot;:([0-9]+),&quot;episode&quot;:([0-9]+),&quot;absolute&quot;:([0-9]+)[^|]*?&quot;tvdb&quot;:{&quot;season&quot;:([0-9]+),&quot;episode&quot;:([0-9]+),&quot;absolute&quot;:([0-9]+)</expression>
 			</RegExp>
 			<!-- insert tvdb listing -->
-			<RegExp conditional="!absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/default/\5/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;\5&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
+			<RegExp conditional="!absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/default/\5/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;\5&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
 				<expression repeat="yes">&lt;Episode&gt;.*?&lt;id&gt;([0-9]+).*?&lt;EpisodeName&gt;([^&lt;]*).*?&lt;EpisodeNumber&gt;([0-9]+)[^&lt;]*.*?&lt;FirstAired&gt;([^&lt;]*)&lt;/FirstAired&gt;.*?&lt;SeasonNumber&gt;([0-9]+)[^&lt;]*.*?&lt;/Episode&gt;</expression>
 			</RegExp>
-			<RegExp conditional="absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
+			<RegExp conditional="absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
 					<expression repeat="yes">&lt;Episode&gt;.*?&lt;id&gt;([0-9]*).*?&lt;EpisodeName&gt;([^&lt;]*).*?&lt;FirstAired&gt;([^&lt;]*).*?&lt;absolute_number&gt;([0-9]*).*?&lt;/Episode&gt;</expression>
 			</RegExp>
-			<RegExp conditional="absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
+			<RegExp conditional="absolutenumber" input="$$1" output="&lt;episode&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/$$10/absolute/\3/$INFO[language].xml&lt;/url&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;id&gt;\1&lt;/id&gt;&lt;aired&gt;\4&lt;/aired&gt;&lt;/episode&gt;" dest="4+">
 				<expression repeat="yes">&lt;Episode&gt;.*?&lt;id&gt;([0-9]*).*?&lt;EpisodeName&gt;([^&lt;]*).*?&lt;EpisodeNumber&gt;([0-9]*).*?&lt;FirstAired&gt;([^&lt;]*).*?&lt;SeasonNumber&gt;0&lt;/SeasonNumber&gt;.*?&lt;/Episode&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -119,47 +119,47 @@
 				<expression>([^\|,]+)$</expression>
 			</RegExp>
 			<!-- actors with thumbs -->
-			<RegExp input="$$5" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\3&lt;/role&gt;&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;&lt;/actor&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\3&lt;/role&gt;&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;&lt;/actor&gt;" dest="4+">
 				<expression repeat="yes" noclean="1,2,3">&lt;Actor&gt;.*?&lt;Image&gt;([^&lt;]+)&lt;/Image&gt;.*?&lt;Name&gt;([^&lt;]*)&lt;/Name&gt;.*?&lt;Role&gt;([^&lt;]*)</expression>
 			</RegExp>
 			<!-- actors without thumbs -->
 			<RegExp input="$$5" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\3&lt;/role&gt;&lt;/actor&gt;" dest="4+">
 				<expression repeat="yes" noclean="1,2,3">&lt;Actor&gt;.*?&lt;Image&gt;([^&lt;]*)&lt;/Image&gt;.*?&lt;Name&gt;([^&lt;]*)&lt;/Name&gt;.*?&lt;Role&gt;([^&lt;]*)</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;blank&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;season&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;season&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;-1&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;-1&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
-			<RegExp conditional="fanart" input="$$7" output="&lt;fanart url=&quot;http://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="4+">
+			<RegExp conditional="fanart" input="$$7" output="&lt;fanart url=&quot;https://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="4+">
 				<RegExp input="$$5" output="&lt;thumb dim=&quot;\2&quot; colors=&quot;\3&quot; preview=&quot;_cache/\1&quot;&gt;\1&lt;/thumb&gt;" dest="7+">
 					<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;fanart&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;([^&lt;]*)&lt;/BannerType2&gt;[^&lt;]*&lt;Colors&gt;([^&lt;]*)&lt;/Colors&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 				</RegExp>
@@ -169,7 +169,7 @@
 				<expression noclean="1"/>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="4+">
-				<RegExp input="$$2" output="&lt;url cache=&quot;$$2-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;" dest="7">
+				<RegExp input="$$2" output="&lt;url cache=&quot;$$2-$INFO[language].xml&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;" dest="7">
 					<expression/>
 				</RegExp>
 				<RegExp input="$$2" output="&lt;url cache=&quot;$$2-xem.xml&quot;&gt;http://thexem.de/map/all?id=\1&amp;origin=tvdb&lt;/url&gt;" dest="7+">
@@ -231,7 +231,7 @@
 			<RegExp input="$$8" output="&lt;title&gt;\1&lt;/title&gt;" dest="4+">
 				<expression>&lt;EpisodeName&gt;([^&lt;]*)&lt;/EpisodeName&gt;</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$8" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression>&lt;filename&gt;([^&lt;]+)&lt;/filename&gt;</expression>
 			</RegExp>
 			<RegExp input="$$8" output="&lt;aired&gt;\1&lt;/aired&gt;" dest="4+">

--- a/metadata.tv.daum.net/daum-tv.xml
+++ b/metadata.tv.daum.net/daum-tv.xml
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2010-09-21" language="ko">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://movie.daum.net/tv/detail/main.do?tvProgramId=\1&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://movie.daum.net/tv/detail/main.do?tvProgramId=\1&lt;/url&gt;" dest="3">
 			<expression>movie\.daum\.net[^\?]*\?tvProgramId=(\d+)</expression>
 		</RegExp>
 	</NfoUrl>
 	<EpisodeGuideUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=\1&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=\1&lt;/url&gt;" dest="3">
 			<expression>movie\.daum\.net[^\?]*\?tvProgramId=(\d+)</expression>
 		</RegExp>
 	</EpisodeGuideUrl>
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1 $$2" output="&lt;url&gt;http://movie.daum.net/search.do?type=tv&amp;q=\1&lt;/url&gt;" dest="3">
+		<RegExp input="$$1 $$2" output="&lt;url&gt;https://movie.daum.net/search.do?type=tv&amp;q=\1&lt;/url&gt;" dest="3">
 			<expression/>
 		</RegExp>
 	</CreateSearchUrl>
 	<GetSearchResults dest="1">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="1">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2 (\3)&lt;/title&gt;&lt;url&gt;http://movie.daum.net/tv/detail/main.do?tvProgramId=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
-				<expression repeat="yes">class="fl srch"&gt;&lt;a href="http://movie.daum.net/tv/detail/main.do\?tvProgramId=(\d+)"[^&gt;]*&gt;([^"]*)&lt;/a&gt;\s*\((\d*)\)&lt;/span&gt;[^\(]*"fs13"&gt;([^"]*)&lt;/span</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2 (\3)&lt;/title&gt;&lt;url&gt;https://movie.daum.net/tv/detail/main.do?tvProgramId=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
+				<expression repeat="yes">class="fl srch"&gt;&lt;a href="https://movie.daum.net/tv/detail/main.do\?tvProgramId=(\d+)"[^&gt;]*&gt;([^"]*)&lt;/a&gt;\s*\((\d*)\)&lt;/span&gt;[^\(]*"fs13"&gt;([^"]*)&lt;/span</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -76,7 +76,7 @@
 			<RegExp input="$$1" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="4+">
 				<expression>&lt;h4&gt;네티즌 평점&lt;/h4&gt;&lt;/a&gt;\s*&lt;span class="fs11 fc3"&gt;\((\d+) 참여\)&lt;/span&gt;</expression>
 			</RegExp>
-			<RegExp conditional="!useAgent" input="$$1" output="&lt;episodeguide&gt;&lt;url cache=&quot;daum-tvep-$$2-1.htm&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
+			<RegExp conditional="!useAgent" input="$$1" output="&lt;episodeguide&gt;&lt;url cache=&quot;daum-tvep-$$2-1.htm&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
 				<expression/>
 			</RegExp>
 			<RegExp conditional="useAgent" input="$$1" output="&lt;episodeguide&gt;&lt;url&gt;http://127.0.0.1:8081/fetch?type=daumtv&amp;id=$$2&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
@@ -98,13 +98,13 @@
                                 <RegExp input="$$10" output="24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1" dest="11">
                                         <expression/>
                                 </RegExp>
-                                <RegExp input="$$11" output="&lt;episode&gt;&lt;url cache=&quot;daum-tvep-$$2-1.htm&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=$$10&amp;ep=\1&lt;/url&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="12">
+                                <RegExp input="$$11" output="&lt;episode&gt;&lt;url cache=&quot;daum-tvep-$$2-1.htm&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=$$10&amp;ep=\1&lt;/url&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="12">
                                         <expression repeat="yes">(\d+)</expression>
                                 </RegExp>
 				<expression noclean="1"/>
 			</RegExp>
 			<!-- correct episode page -->
-			<RegExp input="$$1" output="&lt;url cache=&quot;daum-tvep-$$10-1.htm&quot; function=&quot;GetEpisodePages&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=\2&lt;/url&gt;" dest="9">
+			<RegExp input="$$1" output="&lt;url cache=&quot;daum-tvep-$$10-1.htm&quot; function=&quot;GetEpisodePages&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=\2&lt;/url&gt;" dest="9">
 				<expression>&lt;li id="itemId_\d+"</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -142,15 +142,15 @@
 				<expression noclean="1">&lt;div class="pagination"&gt;(.*?)&lt;/div&gt;</expression>
 			</RegExp>
 			<!-- current page -->
-			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePage&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5">
+			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePage&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5">
 				<expression>"current"&gt;(\d+)&lt;</expression>
 			</RegExp>
 			<!-- other pages in list -->
-			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePage&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePage&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5+">
 				<expression repeat="yes">&lt;a href="[^"]*"&gt;(\d+)&lt;</expression>
 			</RegExp>
 			<!-- next page list -->
-			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePages&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;url cache=&quot;daum-tvep-$$2-\1.htm&quot; function=&quot;GetEpisodePages&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=\1&lt;/url&gt;" dest="5+">
 				<expression>&lt;a href="\?tvProgramId=$$2&amp;page=(\d+)"[^&gt;]*&gt;\d+~\d+\s*&lt;span[^&gt;]*&gt;\s*&amp;gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -164,7 +164,7 @@
 			<RegExp input="$$1" output="\1" dest="10">
 				<expression>&lt;span class="current"&gt;(\d+)&lt;/span&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;daum-tvep-$$2-$$10.htm&quot;&gt;http://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=$$10&amp;ep=\1&lt;/url&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;daum-tvep-$$2-$$10.htm&quot;&gt;https://movie.daum.net/tv/detail/episode.do?tvProgramId=$$2&amp;page=$$10&amp;ep=\1&lt;/url&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;1&lt;/season&gt;&lt;/episode&gt;" dest="5">
 				<expression repeat="yes">&lt;li id="itemId_(\d+)"</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -189,8 +189,8 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression noclean="1">&lt;h3 class="tit"&gt;포토 리스트&lt;/h3&gt;(.*)&lt;!-- 포토 End</expression>
 			</RegExp>
-			<RegExp input="$$6" output="&lt;thumb preview=&quot;http://\1/S150x125/\2&quot;&gt;http://\1/image/\2&lt;/thumb&gt;" dest="5">
-				<expression repeat="yes" noclean="1">&lt;img src="http://([^/]+)/S150x125/([^"]+)"</expression>
+			<RegExp input="$$6" output="&lt;thumb preview=&quot;https://\1/S150x125/\2&quot;&gt;https://\1/image/\2&lt;/thumb&gt;" dest="5">
+				<expression repeat="yes" noclean="1">&lt;img src="https://([^/]+)/S150x125/([^"]+)"</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -2,36 +2,36 @@
 <!-- should be self-explanatory -->
 <scraper framework="1.1" date="2013-04-04">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
-			<expression>http://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
+		<RegExp input="$$1" output="&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
+			<expression>https://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;http://thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;https://thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
 			<expression>imdb....?/title/tt([0-9]*)</expression>
 		</RegExp>
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;http://thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;https://thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
 			<expression>imdb....?/Title\?([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
 
 	<GetTVDBId dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 	</GetTVDBId>
 
 	<EpisodeGuideUrl dest="3">
 		<RegExp input="$$1" output="\1" dest="3">
-			<expression>(.*?http://www.thetvdb.com.*)</expression>
+			<expression>(.*?https://www.thetvdb.com.*)</expression>
 		</RegExp>
 		<RegExp input="$$1" output="\1" dest="3">
-			<expression>(.*?http://thetvdb.com.*)</expression>
+			<expression>(.*?https://thetvdb.com.*)</expression>
 		</RegExp>
 	</EpisodeGuideUrl>
 
 	<!-- input:	$1=query string -->
 	<!-- returns:	the url we should use to do the search -->
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;cache-\1$$4-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;cache-\1$$4-$INFO[language].xml&quot;&gt;https://thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
 			<RegExp input="$$2" output="%20(\1)" dest="4">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
@@ -43,7 +43,7 @@
 	<!-- returns:	results in xml format <results><movie><title>*</title><url>*</url>*#urls<extra>*</extra></movie>*</results> -->
 	<GetSearchResults dest="1">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="1">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
 				<expression repeat="yes">&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;[^&lt;]*&lt;language&gt;([^&lt;]*)&lt;/language&gt;[^&lt;]*&lt;SeriesName&gt;([^&lt;]*)&lt;/SeriesName&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -119,7 +119,7 @@
 				<expression>([^\|,]+)$</expression>
 			</RegExp>
 			<!-- actors with thumbs -->
-			<RegExp input="$$5" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\3&lt;/role&gt;&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;&lt;/actor&gt;" dest="4+">
+			<RegExp input="$$5" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\3&lt;/role&gt;&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;&lt;/actor&gt;" dest="4+">
 				<expression repeat="yes" noclean="1,2,3">&lt;Actor&gt;.*?&lt;Image&gt;([^&lt;]+)&lt;/Image&gt;.*?&lt;Name&gt;([^&lt;]*)&lt;/Name&gt;.*?&lt;Role&gt;([^&lt;]*)</expression>
 			</RegExp>
 			<!-- actors without thumbs -->
@@ -141,7 +141,7 @@
 
 	<GetArt dest="3">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseArt&quot; cache=&quot;\1-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/banners.xml&lt;/url&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseArt&quot; cache=&quot;\1-$INFO[language].xml&quot;&gt;https://thetvdb.com/api/1D62F2F90030C444/series/\1/banners.xml&lt;/url&gt;" dest="4">
 				<expression/>
 			</RegExp>
 			<expression noclean="1"/>
@@ -149,40 +149,40 @@
 	</GetArt>
 	<ParseArt dest="3">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;blank&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;season&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;season&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;-1&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$1" output="&lt;thumb aspect=&quot;poster&quot; type=&quot;season&quot; season=&quot;-1&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
-			<RegExp conditional="fanart" input="$$5" output="&lt;fanart url=&quot;http://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="4+">
+			<RegExp conditional="fanart" input="$$5" output="&lt;fanart url=&quot;https://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;" dest="4+">
 				<RegExp input="$$1" output="&lt;thumb dim=&quot;\2&quot; colors=&quot;\3&quot; preview=&quot;_cache/\1&quot;&gt;\1&lt;/thumb&gt;" dest="5">
 					<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;fanart&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;([^&lt;]*)&lt;/BannerType2&gt;[^&lt;]*&lt;Colors&gt;([^&lt;]*)&lt;/Colors&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 				</RegExp>
@@ -201,7 +201,7 @@
 	<GetEpisodeList dest="3">
 		<RegExp input="$$4" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="3">
 			<RegExp input="$$2" output="\2-\3" dest="10">
-				<expression>http://(?:www\.)?thetvdb.com/api/(.+)/series/([0-9]*)/all/(.+).zip</expression>
+				<expression>https://(?:www\.)?thetvdb.com/api/(.+)/series/([0-9]*)/all/(.+).zip</expression>
 			</RegExp>
 			<RegExp conditional="!dvdorder">
 				<!-- Regular episodes (Absolute order) -->
@@ -304,7 +304,7 @@
 				</RegExp>
 				<expression/>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
+			<RegExp input="$$8" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="4+">
 				<expression>&lt;filename&gt;([^&lt;]+)&lt;/filename&gt;</expression>
 			</RegExp>
 			<RegExp input="$$8" output="&lt;aired&gt;\1&lt;/aired&gt;" dest="4+">

--- a/metadata.tvshows.animenewsnetwork.com/ann.xml
+++ b/metadata.tvshows.animenewsnetwork.com/ann.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2010-03-26">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;\1.html&quot;&gt;http://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;\1.html&quot;&gt;https://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
 			<expression>animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
 
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$6" output="&lt;url&gt;http://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=web&amp;xmltype=attributebased&amp;Query=\1+site%3Aanimenewsnetwork.com%2Fencyclopedia&lt;/url&gt;" dest="3">
+		<RegExp input="$$6" output="&lt;url&gt;https://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=web&amp;xmltype=attributebased&amp;Query=\1+site%3Aanimenewsnetwork.com%2Fencyclopedia&lt;/url&gt;" dest="3">
 			<RegExp input="$$1" output="$$1%20%2dEND" dest="5">
 				<expression/>
 			</RegExp>
@@ -20,8 +20,8 @@
 
 	<GetSearchResults dest="3">
 		<RegExp input="$$5" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results sorted=&quot;Yes&quot;&gt;\1&lt;/results&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url cache=&quot;\2.html&quot;&gt;http://www.animenewsnetwork.com/encyclopedia/anime.php?id=\2&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/entity&gt;" dest="5+">
-				<expression repeat="yes">&lt;web:WebResult Title=&quot;([^&gt;&quot;]+?)&quot; [^&gt;]* Url=&quot;http://www.animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]+?)&quot; [^&gt;]*&gt;</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url cache=&quot;\2.html&quot;&gt;https://www.animenewsnetwork.com/encyclopedia/anime.php?id=\2&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<expression repeat="yes">&lt;web:WebResult Title=&quot;([^&gt;&quot;]+?)&quot; [^&gt;]* Url=&quot;https://www.animenewsnetwork.com/encyclopedia/anime.php\?id=([0-9]+?)&quot; [^&gt;]*&gt;</expression>
 			</RegExp>
 			<expression clear="yes" noclean="1"/>
 		</RegExp>
@@ -100,11 +100,11 @@
 			</RegExp>
 
 			<RegExp conditional="fanart" input="$$1" output="&lt;chain function=&quot;GetFanartCollector&quot;&gt;Collect All Fanart&lt;/chain&gt;" dest="5+">
-				<RegExp input="$$1" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetFanart&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
+				<RegExp input="$$1" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetFanart&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
 					<expression trim="1" encode="1">page_header&quot;&gt;([^\(&lt;]*)</expression>
 				</RegExp>
 
-				<RegExp conditional="fanartalt" input="$$7" output="&lt;url function=&quot;GetFanart&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
+				<RegExp conditional="fanartalt" input="$$7" output="&lt;url function=&quot;GetFanart&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
 					<RegExp input="$$1" output="\1" dest="6">
 						<expression noclean="1">&lt;STRONG&gt;Alternative title:&lt;/STRONG&gt;(.*?)&lt;DIV CLASS=&quot;encyc-info-type br&quot;&gt;</expression>
 					</RegExp>
@@ -116,13 +116,13 @@
 				<expression noclean="1"/>
 			</RegExp>
 
-			<RegExp conditional="banner" input="$$6" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetBanner&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
+			<RegExp conditional="banner" input="$$6" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetBanner&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="6">
 					<expression trim="1" encode="1">page_header&quot;&gt;([^\(&lt;]*)</expression>
 				</RegExp>
 				<expression noclean="1"/>
 			</RegExp>
-			<RegExp conditional="poster" input="$$6" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetPoster&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
+			<RegExp conditional="poster" input="$$6" output="&lt;url cache=&quot;$$2-tvdb-search.xml&quot; function=&quot;GetPoster&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=\1&amp;language=all&lt;/url&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="6">
 					<expression trim="1" encode="1">page_header&quot;&gt;([^\(&lt;]*)</expression>
 				</RegExp>
@@ -132,7 +132,7 @@
 				<expression noclean="1">/thumbnails/fit200x200/encyc/([^']*)</expression>
 			</RegExp>
 
-			<RegExp input="$$2" output="&lt;episodeguide&gt;&lt;url&gt;http://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&amp;page=25&lt;/url&gt;&lt;/episodeguide&gt;" dest="5+">
+			<RegExp input="$$2" output="&lt;episodeguide&gt;&lt;url&gt;https://www.animenewsnetwork.com/encyclopedia/anime.php?id=\1&amp;page=25&lt;/url&gt;&lt;/episodeguide&gt;" dest="5+">
 				<expression/>
 			</RegExp>
 
@@ -146,11 +146,11 @@
 		</RegExp>
 
 		<!-- Get the first match -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetFanartData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetFanartData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 		<!-- Or get the one with the best year match if found -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetFanartData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetFanartData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;FirstAired&gt;$$6.*?&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 		</RegExp>
 		<RegExp input="$$1" output="&lt;details/&gt;" dest="3">
@@ -177,7 +177,7 @@
 	</GetFanartData>
 
 	<GetFanartCollector dest="3" clearbuffers="no">
-		<RegExp input="$$9" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;fanart url=&quot;http://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$9" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;fanart url=&quot;https://thetvdb.com/banners/&quot;&gt;\1&lt;/fanart&gt;&lt;/details&gt;" dest="3">
 			<expression noclean="1"/>
 		</RegExp>
 	</GetFanartCollector>
@@ -188,24 +188,24 @@
 		</RegExp>
 
 		<!-- Get the first match -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetBannerData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetBannerData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 <!--                 Or get the one with the best year match if found -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetBannerData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetBannerData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;FirstAired&gt;$$6.*?&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 		</RegExp>
 	</GetBanner>
 
 	<GetBannerData dest="3">
 		<RegExp input="$$6" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6">
+			<RegExp input="$$1" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6">
 				<expression repeat="yes" clear="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;[a-z]*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6+">
+			<RegExp input="$$1" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;[a-z]*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6+">
+			<RegExp input="$$1" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;blank&lt;/BannerType2&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -218,18 +218,18 @@
 		</RegExp>
 
 		<!-- Get the first match -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetPosterData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetPosterData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 		<!-- Or get the one with the best year match if found -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetPosterData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetPosterData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;FirstAired&gt;$$6.*?&lt;id&gt;([0-9]*)&lt;/id&gt;</expression>
 		</RegExp>
 	</GetPoster>
 
 	<GetPosterData dest="3">
 		<RegExp input="$$6" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;thumb&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6">
+			<RegExp input="$$1" output="&lt;thumb&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="6">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;poster&lt;/BannerType&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -237,7 +237,7 @@
 	</GetPosterData>
 
 	<GetANNThumbnail dest="3">
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;thumb&gt;http://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;thumb&gt;https://www.animenewsnetwork.com/thumbnails/fit200x200/encyc/\1&lt;/thumb&gt;&lt;/details&gt;" dest="3">
 			<expression noclean="1"/>
 		</RegExp>
 	</GetANNThumbnail>
@@ -258,12 +258,12 @@
 			</RegExp> 
 
 			<!-- Allows same amount of specials as normal season -->
-			<RegExp conditioanl="specials" input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;bing.xml&quot;&gt;http://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=InstantAnswer&amp;xmltype=attributebased&amp;Query=1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;/episode&gt;" dest="6+">
+			<RegExp conditioanl="specials" input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;bing.xml&quot;&gt;https://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=InstantAnswer&amp;xmltype=attributebased&amp;Query=1&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;epnum&gt;\1&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;/episode&gt;" dest="6+">
 				<expression repeat="yes">CLASS=n&gt;([0-9]+?)\.&lt;/TD&gt;</expression>
 			</RegExp> 
 
 			<!-- Single episode OVA without episode listing -->
-			<RegExp conditional="specials" input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;bing.xml&quot;&gt;http://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=InstantAnswer&amp;xmltype=attributebased&amp;Query=1&lt;/url&gt;&lt;id&gt;1&lt;/id&gt;&lt;epnum&gt;1&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;/episode&gt;" dest="6+">
+			<RegExp conditional="specials" input="$$1" output="&lt;episode&gt;&lt;url cache=&quot;bing.xml&quot;&gt;https://api.bing.com/xml.aspx?AppId=16E50AB9947899C41433EB944C60174737855036&amp;Sources=InstantAnswer&amp;xmltype=attributebased&amp;Query=1&lt;/url&gt;&lt;id&gt;1&lt;/id&gt;&lt;epnum&gt;1&lt;/epnum&gt;&lt;season&gt;0&lt;/season&gt;&lt;/episode&gt;" dest="6+">
 				<expression repeat="yes">&lt;title&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -296,7 +296,7 @@
 			</RegExp>
 
 			<!-- Search TVDB for episode overview and other extras -->
-			<RegExp conditional="details" input="$$1" output="&lt;url cache=&quot;\1-tvdb-search.xml&quot; function=&quot;GetEpisodeExtra&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=$$7&amp;language=all&lt;/url&gt;" dest="6+">
+			<RegExp conditional="details" input="$$1" output="&lt;url cache=&quot;\1-tvdb-search.xml&quot; function=&quot;GetEpisodeExtra&quot;&gt;https://www.thetvdb.com/api/GetSeries.php?seriesname=$$7&amp;language=all&lt;/url&gt;" dest="6+">
 				<RegExp input="$$1" output="\1" dest="7">
 					<expression trim="1" encode="1">&lt;title&gt;([^&lt;]*) \(.*?\) - Anime News Network&lt;/title&gt;</expression>
 				</RegExp>
@@ -308,7 +308,7 @@
 
 	<GetEpisodeExtra dest="3" clearbuffers="no">
 		<!-- Get the first match -->
-		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetEpisodeExtraData&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;&lt;url cache=&quot;\1.xml&quot; function=&quot;GetEpisodeExtraData&quot;&gt;https://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/en.zip&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression clear="yes">&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 	</GetEpisodeExtra>

--- a/metadata.tvshows.themoviedb.org/tmdb.xml
+++ b/metadata.tvshows.themoviedb.org/tmdb.xml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2013-10-26">
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://api.themoviedb.org/3/search/tv?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url&gt;https://api.themoviedb.org/3/search/tv?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="3">
 			<expression noclean="1" />
 		</RegExp>
 	</CreateSearchUrl>
 
 	<NfoUrl dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
 				<expression clear="yes" noclean="1">imdb....?/title/(tt[0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
 				<expression noclean="1">imdb....?/Title\?([0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=tvdb_id&lt;/url&gt;" dest="5">
-				<expression noclean="1">http://(?:www\.)?thetvdb\.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;external_source=tvdb_id&lt;/url&gt;" dest="5">
+				<expression noclean="1">https://(?:www\.)?thetvdb\.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
 				<expression noclean="1">themoviedb\.org/tv/([0-9]+)</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -25,7 +25,7 @@
 	</NfoUrl>
 	<GetTMDBId dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$7" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
+			<RegExp input="$$7" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
 				<RegExp input="$$1" output="\1" dest="7">
 					<expression noclean="1">"tv_results":\[([^\]]+)\]</expression>
 				</RegExp>
@@ -37,10 +37,10 @@
 
 	<GetSearchResults dest="8">
 		<RegExp input="$$3" output="&lt;results&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3">
 				<expression repeat="yes">&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:&quot;([0-9]+).*?&quot;original_name&quot;:&quot;([^&quot;]*)&quot;</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
 				<expression repeat="yes">&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:null.*?&quot;original_name&quot;:&quot;([^&quot;]*)&quot;</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -110,7 +110,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$2-en.json&quot;&gt;http://api.themoviedb.org/3/tv/$$2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$2-en.json&quot;&gt;https://api.themoviedb.org/3/tv/$$2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -130,7 +130,7 @@
 			<RegExp input="$$1" output="\1" dest="5">
 				<expression>"id":([0-9]+),"in_production"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;https://api.themoviedb.org/3/tv/$$5/season/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="4">
 				<expression repeat="yes">"season_number":([0-9]+)</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -141,7 +141,7 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression clear="yes">"season_number":([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\3&lt;/title&gt;&lt;aired&gt;\1&lt;/aired&gt;&lt;epnum&gt;\2&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-episode-s$$6e\2.json&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/$$6/episode/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\2&lt;/id&gt;&lt;/episode&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\3&lt;/title&gt;&lt;aired&gt;\1&lt;/aired&gt;&lt;epnum&gt;\2&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-episode-s$$6e\2.json&quot;&gt;https://api.themoviedb.org/3/tv/$$5/season/$$6/episode/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\2&lt;/id&gt;&lt;/episode&gt;" dest="4">
 				<expression repeat="yes" clear="yes">"air_date":"([^"]+)","[^\]]*\],"episode_number":([0-9]+),"[^\]]*\],"name":"((?:[^"]|(?&lt;=\\)")*)",</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -166,7 +166,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBEpisodeTitle&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;http://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBEpisodeTitle&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;https://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -193,7 +193,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;http://api.themoviedb.org/3/tv/$$6/season/$$11/episode/$$10?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;https://api.themoviedb.org/3/tv/$$6/season/$$11/episode/$$10?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -246,13 +246,13 @@
 
 	<GetCast dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseCast&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
 				<expression>^([0-9]+)$</expression> />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2/episode/\3?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseCast&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2/episode/\3?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
 				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression> />
 			</RegExp>
 			<expression noclean="1" />
@@ -284,10 +284,10 @@
 
 	<GetArt dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseArt&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseArt&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -327,13 +327,13 @@
 	</ParseArt>
 	<GetSeasonArt clearbuffers="no" dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression>^([0-9]+)\|</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="10">
 				<expression>\|([0-9]+)$</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseSeasonArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseSeasonArt&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<expression>^([0-9]+)\|([0-9]+)$</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -355,10 +355,10 @@
 	</ParseSeasonArt>
 	<GetEpisodeArt dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=f7f51775877e0bb6703520952b3c7840&lt;/url&gt;" dest="5">
 				<expression>^([0-9]+)\|</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseEpisodeArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2/episode/\3/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseEpisodeArt&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2/episode/\3/images?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -378,7 +378,7 @@
 
 	<GetTVDBWideBanners dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTVDBWideBanners&quot; cache=&quot;tvdb-\1-banners.xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/banners.xml&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTVDBWideBanners&quot; cache=&quot;tvdb-\1-banners.xml&quot;&gt;https://thetvdb.com/api/1D62F2F90030C444/series/\1/banners.xml&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -389,25 +389,25 @@
 			<RegExp input="$$1" output="\1" dest="3">
 				<expression noclean="1">&lt;Banners&gt;(.*)</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;graphical&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;text&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;series&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;blank&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;&lt;/Language&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\2&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;$INFO[language]&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;http://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
+			<RegExp input="$$3" output="&lt;thumb aspect=&quot;banner&quot; type=&quot;season&quot; season=&quot;\3&quot;&gt;https://thetvdb.com/banners/\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">&lt;BannerPath&gt;([^&lt;]*)&lt;/BannerPath&gt;[^&lt;]*&lt;BannerType&gt;season&lt;/BannerType&gt;[^&lt;]*&lt;BannerType2&gt;seasonwide&lt;/BannerType2&gt;[^&lt;]*&lt;Language&gt;((?!$INFO[language])[a-z])*&lt;/Language&gt;[^&lt;]*[^S]*Season&gt;([0-9]+)&lt;/Season&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />

--- a/metadata.universal/universal.xml
+++ b/metadata.universal/universal.xml
@@ -2,23 +2,23 @@
 <scraper framework="1.1" date="2014-07-24">
 	<NfoUrl dest="3">
 		<RegExp input="$INFO[searchservice]" output="$$16" dest="3">
-			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="16">
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\2.json&quot;&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;\2&lt;/id&gt;&lt;/details&gt;" dest="16">
 				<expression clear="yes" noclean="1">(themoviedb.org/movie/)([0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;https://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
 				<expression>imdb....?/title/tt([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;http://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
+			<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-tt\1.json&quot;&gt;https://api.tmdb.org/3/movie/tt\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;&lt;/details&gt;" dest="16">
 				<expression>imdb....?/Title\?t{0,2}([0-9]+)</expression>
 			</RegExp>
 			<expression>themoviedb.org</expression>
 		</RegExp>
 
 		<RegExp input="$INFO[searchservice]" output="$$16" dest="3">
-			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1|accept-language=en-us/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;https://www.imdb.com/title/tt\1|accept-language=en-us/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16">
 				<expression clear="yes" noclean="1">imdb....?/Title\?([0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;http://akas.imdb.com/title/tt\1|accept-language=en-us/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tt\1-main.html&quot;&gt;https://www.imdb.com/title/tt\1|accept-language=en-us/&lt;/url&gt;&lt;id&gt;tt\1&lt;/id&gt;" dest="16+">
 				<expression noclean="1">imdb....?/title/tt([0-9]*)</expression>
 			</RegExp>
 			<expression>IMDb</expression>
@@ -26,7 +26,7 @@
 	</NfoUrl>
 	<CreateSearchUrl dest="3" clearbuffers="no">
 		<RegExp input="$INFO[searchservice]" output="$$17" dest="3">
-			<RegExp input="$$1" output="&lt;url&gt;http://api.tmdb.org/3/search/movie?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;year=$$4&lt;/url&gt;" dest="17">
+			<RegExp input="$$1" output="&lt;url&gt;https://api.tmdb.org/3/search/movie?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;query=\1&amp;amp;year=$$4&lt;/url&gt;" dest="17">
 				<RegExp input="$$2" output="\1" dest="4">
 					<expression clear="yes">(.+)</expression>
 				</RegExp>
@@ -35,7 +35,7 @@
 			<expression>themoviedb.org</expression>
 		</RegExp>
 		<RegExp input="$INFO[searchservice]" output="$$17" dest="3">
-			<RegExp input="$$1" output="&lt;url&gt;http://akas.imdb.com/find?q=\1&amp;s=tt|accept-language=en-us&lt;/url&gt;" dest="17">
+			<RegExp input="$$1" output="&lt;url&gt;https://www.imdb.com/find?q=\1&amp;s=tt|accept-language=en-us&lt;/url&gt;" dest="17">
 				<RegExp input="$$2" output="%20(\1)" dest="4">
 					<expression clear="yes">(.+)</expression>
 				</RegExp>
@@ -50,13 +50,13 @@
 	<GetSearchResults dest="8">
 		<RegExp input="$INFO[searchservice]" output="$$17" dest="8">
 			<RegExp input="$$5" output="&lt;results&gt;\1&lt;/results&gt;" dest="17">
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5">
 					<expression repeat="yes">&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;[^&quot;]*&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;,&quot;title&quot;:&quot;([^&quot;]*)&quot;</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;http://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\2.json&quot;&gt;https://api.tmdb.org/3/movie/\2?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes">&quot;release_date&quot;:&quot;([0-9]+)-.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;http://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=f7f51775877e0bb6703520952b3c7840&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes">&quot;release_date&quot;:null.*?&quot;id&quot;:([0-9]*),&quot;original_title&quot;:&quot;([^&quot;]*)&quot;,&quot;original_language&quot;:&quot;[^&quot;]*&quot;</expression>
 				</RegExp>
 				<expression noclean="1" />
@@ -69,25 +69,25 @@
 				<RegExp input="$$1" output="\1" dest="7">
 					<expression clear="yes">/title/([t0-9]*)/(combined|faq|releaseinfo|vote)</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7|accept-language=en-us/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;https://www.imdb.com/title/$$7|accept-language=en-us/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5">
 					<expression clear="yes" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?([^&quot;]*?)(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\)</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;http://akas.imdb.com/title/$$7|accept-language=en-us/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\1&lt;/year&gt;&lt;url cache=&quot;$$7-main.html&quot;&gt;https://www.imdb.com/title/$$7|accept-language=en-us/&lt;/url&gt;&lt;id&gt;$$7&lt;/id&gt;&lt;/entity&gt;" dest="5+">
 					<expression fixchars="2" noclean="1">&lt;meta name=&quot;title&quot; content=&quot;(?:&amp;#x22;)?[^&quot;]*?(?:&amp;#x22;)? \([^\(]*?([0-9]{4})(?:–\s)?\).*?Also Known As:&lt;/h4&gt;([^\n]*)</expression>
 				</RegExp>
 				<RegExp input="$$1" output="\1" dest="4">
 					<expression noclean="1">&lt;table class=&quot;findList&quot;(.*?)&lt;/div</expression>
 				</RegExp>
-				<RegExp conditional="fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp conditional="fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;https://www.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s|\(Short\)\s|\(TV\sMini-Series\)\s|\(TV\sSeries\)\s|\(TV\sShort\)\s|\(Short\)\s|\(Short\)\s)?&lt;</expression>
 				</RegExp>
-				<RegExp conditional="!fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp conditional="!fullimdbsearch" input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;https://www.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV\sMovie\)\s|\(TV\sSpecial\)\s|\(Video\)\s)?&lt;</expression>
 				</RegExp>
-				<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
+				<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\4&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;https://www.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s&lt;br/&gt;aka\s&lt;i&gt;&quot;([^&quot;]*)</expression>
 				</RegExp>
-				<RegExp input="$INFO[imdbsearchlanguage]" output="&lt;url function=&quot;GetAKASearchResults&quot;&gt;http://akas.imdb.com/find?q=$$9&amp;s=tt|accept-language=$INFO[imdbsearchlanguage]&lt;/url&gt;" dest="5+">
+				<RegExp input="$INFO[imdbsearchlanguage]" output="&lt;url function=&quot;GetAKASearchResults&quot;&gt;https://www.imdb.com/find?q=$$9&amp;s=tt|accept-language=$INFO[imdbsearchlanguage]&lt;/url&gt;" dest="5+">
 					<expression>^(?:bg-bg|cs-cz|el-gr|es-ar|da-dk|de-at|de-de|fi-fi|fr-fr|hr-hr|he-il|hu-hu|it-it|ja-jp|nb-no|nl-nl|pl-pl|pt-pt|ro-ro|ru-ru|se-se|sl-si|sr-rs|th-th|tr-tr)$</expression>
 				</RegExp>
 				<expression clear="yes" noclean="1"/>
@@ -102,7 +102,7 @@
 			<RegExp input="$$1" output="\1" dest="4">
 				<expression noclean="1">&lt;table class=&quot;findList&quot;(.*?)&lt;/div</expression>
 			</RegExp>
-			<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;http://akas.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5">
+			<RegExp input="$$4" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;\1-main.html&quot;&gt;https://www.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5">
 				<expression repeat="yes" noclean="1,2">&lt;td\sclass=&quot;result_text&quot;&gt;\s&lt;a\shref=&quot;/title/([t0-9]*)/[^&gt;]*&gt;(?:&amp;#x22;)?([^&lt;]*?)(?:&amp;#x22;)?&lt;/a&gt;\s*(?:\([IV]+\) )?\([^\(]*?([0-9]{4})[^\)]*\)\s(?:\(TV Movie\) )?&lt;</expression>
 			</RegExp>
 			<expression clear="yes" noclean="1"/>

--- a/metadata.worldart.ru/worldart.xml
+++ b/metadata.worldart.ru/worldart.xml
@@ -34,11 +34,11 @@
 				<expression trim="1">/([^/]+)/review.php</expression>
 			</RegExp>
 			<!-- MPAA -->
-			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;MPAA&quot;&gt;http://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;MPAA&quot;&gt;https://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
 				<expression>imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!-- TOP250 -->
-			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;TOP&quot;&gt;http://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;TOP&quot;&gt;https://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
 				<expression>imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!-- YEAR -->
@@ -49,14 +49,14 @@
 			<RegExp input="$$1" output="&lt;runtime&gt;\1&lt;/runtime&gt;" dest="5+">
 				<expression noclean="1">полнометражный фильм, ([^м]+) мин</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;RUNTIME&quot;&gt;http://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;RUNTIME&quot;&gt;https://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" clear="no">imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!-- RATING -->
 			<RegExp input="$$1" output="&lt;url function=&quot;GetRating&quot;&gt;http://www.world-art.ru/$$7/votes_history.php?id=$$2&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;GetRatingAndVotes&quot;&gt;http://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;GetRatingAndVotes&quot;&gt;https://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" clear="no">imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!-- GENRE -->
@@ -67,7 +67,7 @@
 			<RegExp input="$$1" output="&lt;url function=&quot;GetStudios&quot;&gt;http://www.world-art.ru/$$7/$$7_full_production.php?id=$$2&lt;/url&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;GetIMDBStudios&quot;&gt;http://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;\1-imdb.html&quot; function=&quot;GetIMDBStudios&quot;&gt;https://www.imdb.com/title/tt\1&lt;/url&gt;" dest="5+">
 				<expression noclean="1" clear="no">imdb.com/title/tt([0-9]*)</expression>
 			</RegExp>
 			<!-- DIRECTORS, WRITERS, ACTORS -->


### PR DESCRIPTION
Enable or partially enable HTTPS for all supported scrapers for increased privacy and security.

All scrapers that have had HTTPS enabled or partially enabled have been tested and the common ones have been used by myself for several months without problems.

The common ones have also been thoroughly tested in Emby for some time now.
