### PR TITLE
[metadata.tvdb.com] updated to v2.0.1

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="2.0.0"
+       version="2.0.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]2.0.1[/B]
+- Fixed: Backwards-compatibility code
+
 [B]2.0.0[/B]
 - Updated: Complete rewrite for TVDB API 2.0
 - Added: Language fallback options

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -410,10 +410,10 @@
 			
 			<!-- Backwards-compatibility code.  Scraper will still fail if/when the old URLs 404 (or similar), as this function just won't be run. -->
 			<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeList&quot; post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:\1}|Content-Type=application/json&lt;/url&gt;" dest="5">
-				<expression>http://thetvdb.com/api/.+/series/(\d+)/all/</expression>
+				<expression>http://(?:www\.)?thetvdb\.com/api/.+/series/(\d+)/all/</expression>
 			</RegExp>
 			<RegExp input="$$2" output="https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:\1}|Content-Type=application/json" dest="2">
-				<expression>http://thetvdb.com/api/.+/series/(\d+)/all/</expression>
+				<expression>http://(?:www\.)?thetvdb\.com/api/.+/series/(\d+)/all/</expression>
 			</RegExp>
 		<expression noclean="1"/>
 		</RegExp>


### PR DESCRIPTION
So it turns out that backwards-compatibility code didn't work because I missed out the www on the URL it checked against.

I am so sorry and embarrassed.  I swear I tested it.  I don't know what happened.

### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [ x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0