### PR TITLE
[metadata.tvdb.com] updated to v2.0.4

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="2.0.3"
+       version="2.0.4"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]2.0.4[/B]
+- Fixed: Moved IMDb ratings to prevent clearing buffers before GetActors
+
 [B]2.0.3[/B]
 - Fixed: IMDb series ratings
 - Changed: Added the www back to the artwork URLs

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -152,7 +152,7 @@
 	<!-- input : $$3=series url -->
 	<!-- output: <details><title>*</title><plot>*</plot><id>*</id>...etc...<episodeguide>*</episodeguide></details> -->
 	<GetDetails dest="7" clearbuffers="no">
-		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;!-- $INFO[language] $$14 --&gt;&lt;details&gt;\1&lt;/details&gt;" dest="7">
+		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;details&gt;\1&lt;/details&gt;" dest="7">
 			<RegExp input="$$3" output="\1" dest="19">
 				<expression>Authorization=Bearer%20(.+)&amp;Accept-Language</expression>
 			</RegExp>
@@ -192,6 +192,24 @@
 			<RegExp input="$$1" output="&lt;mpaa&gt;\1&lt;/mpaa&gt;" dest="4+">
 				<expression>"rating": "([^"]*)",</expression>
 			</RegExp>
+			<RegExp input="$$5" output="&lt;genre&gt;\1&lt;/genre&gt;" dest="4+">
+				<RegExp input="$$1" output="\1" dest="5">
+					<expression clear="yes">"genre": \[([^]]*)\]</expression>
+				</RegExp>
+				<expression noclean="1" repeat="yes">"([^"]+)"</expression>
+			</RegExp>
+			<RegExp input="$INFO[language]" output="$$5" dest="4+">
+				<RegExp input="$$14" output="&lt;url function=&quot;GetFallbackDetails&quot; cache=&quot;$$2-$INFO[fallbacklanguage].json&quot;&gt;https://api.thetvdb.com/series/$$2|Authorization=Bearer%20$$19&amp;Accept-Language=$INFO[fallbacklanguage]&lt;/url&gt;" dest="5">
+					<expression clear="yes">(?!^$)</expression>
+				</RegExp>
+				<expression>(?!^\Q$INFO[fallbacklanguage]\E$)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetActors&quot;&gt;\1&lt;/chain&gt;" dest="4+">
+				<expression noclean="1">"id": (\d+),</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetArt&quot;&gt;\1&lt;/chain&gt;" dest="4+">
+				<expression noclean="1">"id": (\d+),</expression>
+			</RegExp>
 			<RegExp input="$$5" output="\1" dest="4+">
 				<RegExp input="$$1" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="5">
 					<expression clear="yes">"siteRating": (?:(\d+(?:\.\d)?)|null)</expression>
@@ -212,24 +230,6 @@
 					<expression>IMDb</expression>
 				</RegExp>
 				<expression noclean="1"/>
-			</RegExp>
-			<RegExp input="$$5" output="&lt;genre&gt;\1&lt;/genre&gt;" dest="4+">
-				<RegExp input="$$1" output="\1" dest="5">
-					<expression clear="yes">"genre": \[([^]]*)\]</expression>
-				</RegExp>
-				<expression noclean="1" repeat="yes">"([^"]+)"</expression>
-			</RegExp>
-			<RegExp input="$INFO[language]" output="$$5" dest="4+">
-				<RegExp input="$$14" output="&lt;url function=&quot;GetFallbackDetails&quot; cache=&quot;$$2-$INFO[fallbacklanguage].json&quot;&gt;https://api.thetvdb.com/series/$$2|Authorization=Bearer%20$$19&amp;Accept-Language=$INFO[fallbacklanguage]&lt;/url&gt;" dest="5">
-					<expression clear="yes">(?!^$)</expression>
-				</RegExp>
-				<expression>(?!^\Q$INFO[fallbacklanguage]\E$)</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetActors&quot;&gt;\1&lt;/chain&gt;" dest="4+">
-				<expression noclean="1">"id": (\d+),</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetArt&quot;&gt;\1&lt;/chain&gt;" dest="4+">
-				<expression noclean="1">"id": (\d+),</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;episodeguide&gt;&lt;url post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:\1}|Content-Type=application/json&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
 				<expression noclean="1">"id": (\d+),</expression>


### PR DESCRIPTION
Fixes using IMDb ratings blocking Actor scraping.
The call to GetIMDBRatingById was simply clearing the buffers before GetActors could use the Authorization token.  Swapping the order around fixed it easily enough.

I may also have inadvertently fixed the issue with IMDb ratings not showing when using German language.
At some point  I had put $INFO[language] (and some random buffer) into a comment on the output of GetDetails for debugging purposes, and _somehow_ this was causing the IMDb page to have German numbering style... _maybe_? 

I do not understand the connection, but I tested it enough to know it works without it, but not with it.  So I removed it.

### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
