### PR TITLE
Ratings code updates

### DIFF
--- a/metadata.common.imdb.com/addon.xml
+++ b/metadata.common.imdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.imdb.com"
        name="IMDB Scraper Library"
-       version="2.9.1"
+       version="2.9.2"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.common.imdb.com/changelog.txt
+++ b/metadata.common.imdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]2.9.2[/B]
+- changed: simplify ratings code
+
 [B]2.9.1[/B]
 - changed: improved USA rating detection
 

--- a/metadata.common.imdb.com/imdb.xml
+++ b/metadata.common.imdb.com/imdb.xml
@@ -28,33 +28,22 @@
 		</RegExp>
 	</ParseIMDBRating>
 
-	<GetIMDBRatingsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBRatings&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1" />
+	<GetIMDBRatingsById dest="5" clearbuffers="no">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-main.html&quot; function=&quot;ParseIMDBRatings&quot;&gt;http://akas.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+			<expression noclean="1">^(tt\d+)</expression>
+		</RegExp>
+		<RegExp input="$$1" output="default=&quot;true&quot;" dest="3">
+			<expression clear="yes">\|default$</expression>
 		</RegExp>
 	</GetIMDBRatingsById>
 	<ParseIMDBRatings dest="5">
 		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;imdb&quot; &gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
+			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;imdb&quot; $$3&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
 				<expression>&lt;span\sitemprop=&quot;ratingValue&quot;&gt;([0-9.]+).*?ratingCount&quot;&gt;([0-9,]+)&lt;</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</ParseIMDBRatings>
-
-	<GetIMDBRatingsByIdAsDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBRatingsAsDef&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1" />
-		</RegExp>
-	</GetIMDBRatingsByIdAsDef>
-	<ParseIMDBRatingsAsDef dest="5">
-		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;imdb&quot; default=&quot;true&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
-				<expression>&lt;span\sitemprop=&quot;ratingValue&quot;&gt;([0-9.]+).*?ratingCount&quot;&gt;([0-9,]+)&lt;</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseIMDBRatingsAsDef>
 
 	<GetIMDBTOP250ById dest="5">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBTOP250&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
@@ -102,46 +91,50 @@
 	</ParseIMDBCountry>
 
 	<GetMetaCriticRatingById dest="5">	<!-- Compatibility function for Pre-Krypton versions-->
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseMetaCriticRating&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-criticreviews.html&quot; function=&quot;ParseMetaCriticRating&quot;&gt;http://akas.imdb.com/title/$$1/criticreviews|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1" />
 		</RegExp>
 	</GetMetaCriticRatingById>
 	<ParseMetaCriticRating dest="5">
 		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;rating&gt;\1.\2&lt;/rating&gt;" dest="2">
-				<expression>&lt;div\sclass=&quot;metacriticScore\sscore_[^\s]+\stitleReviewBarSubItem&quot;&gt;.*?&lt;span&gt;(\d*)(\d)</expression>
+			<RegExp input="$$1" output="\1" dest="6">
+				<expression noclean="1">(&lt;div class=&quot;metascore_block&quot;.*)</expression>
+			</RegExp>
+			<RegExp input="$$6" output="&lt;rating max=&quot;100&quot;&gt;\1&lt;/value&gt;" dest="2">
+				<expression clear="yes">&lt;span itemprop=&quot;ratingValue&quot;&gt;(\d+)&lt;/span&gt;</expression>
+			</RegExp>
+			<RegExp input="$$6" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="2+">
+				<expression>&lt;span itemprop=&quot;ratingCount&quot;&gt;(\d+)&lt;/span&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</ParseMetaCriticRating>
 
-	<GetMetaCriticRatingsById dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseMetaCriticRatings&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1" />
+	<GetMetaCriticRatingsById dest="5" clearbuffers="no">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-criticreviews.html&quot; function=&quot;ParseMetaCriticRatings&quot;&gt;http://akas.imdb.com/title/\1/criticreviews|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+			<expression noclean="1">(tt\d+)</expression>
+		</RegExp>
+		<RegExp input="$$1" output="default=&quot;true&quot;" dest="3">
+			<expression clear="yes">\|default$</expression>
 		</RegExp>
 	</GetMetaCriticRatingsById>
 	<ParseMetaCriticRatings dest="5">
 		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;metacritic&quot; &gt;&lt;value&gt;\1.\2&lt;/value&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
-				<expression>&lt;div\sclass=&quot;metacriticScore\sscore_[^\s]+\stitleReviewBarSubItem&quot;&gt;.*?&lt;span&gt;(\d*)(\d)</expression>
+			<RegExp input="$$4" output="&lt;ratings&gt;&lt;rating name=&quot;metacritic&quot; max=&quot;100&quot; $$3&gt;\1&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
+				<RegExp input="$$1" output="\1" dest="6">
+					<expression clear="yes" noclean="1">(&lt;div class=&quot;metascore_block&quot;.*)</expression>
+				</RegExp>
+				<RegExp input="$$6" output="&lt;value&gt;\1&lt;/value&gt;" dest="4">
+					<expression clear="yes">&lt;span itemprop=&quot;ratingValue&quot;&gt;(\d+)&lt;/span&gt;</expression>
+				</RegExp>
+				<RegExp input="$$6" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="4+">
+					<expression>&lt;span itemprop=&quot;ratingCount&quot;&gt;(\d+)&lt;/span&gt;</expression>
+				</RegExp>
+				<expression noclean="1" clear="yes"/>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</ParseMetaCriticRatings>
-
-	<GetMetaCriticRatingsByIdAsDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseMetaCriticRatingsAsDef&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1" />
-		</RegExp>
-	</GetMetaCriticRatingsByIdAsDef>
-	<ParseMetaCriticRatingsAsDef dest="5">
-		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;metacritic&quot; default=&quot;true&quot;&gt;&lt;value&gt;\1.\2&lt;/value&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
-				<expression>&lt;div\sclass=&quot;metacriticScore\sscore_[^\s]+\stitleReviewBarSubItem&quot;&gt;.*?&lt;span&gt;(\d*)(\d)</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseMetaCriticRatingsAsDef>
 
 	<GetIMDBPlotById dest="5">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;$$1-main.html&quot; function=&quot;ParseIMDBPlot&quot;&gt;http://akas.imdb.com/title/$$1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">

--- a/metadata.common.omdbapi.com/addon.xml
+++ b/metadata.common.omdbapi.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.omdbapi.com"
        name="OMDBAPI common scraper functions"
-       version="1.1.0"
+       version="1.1.1"
        provider-name="Olympia">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.common.omdbapi.com/changelog.txt
+++ b/metadata.common.omdbapi.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.1.1[/B]
+- Changed: Simplify ratings code
+
 [B]1.1.0[/B]
 - Fixed: RT ratings, but users need to obtain their individual omdbapi key at omdbapi.com
 - Added: Prepare for multiple ratings and uniqueid support (requires Kodi v17)

--- a/metadata.common.omdbapi.com/omdbapi.xml
+++ b/metadata.common.omdbapi.com/omdbapi.xml
@@ -19,7 +19,7 @@
 	</GetRTRatingById>
 
 	<!-- Get OMDBAPI URL from IMDb ID for ratings with new method -->
-	<GetRTRatingsById dest="5">
+	<GetRTRatingsById dest="5" clearbuffers="no">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10New&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.omdbapi.com/?i=tt\1&amp;apikey=$INFO[omdbapikey]&amp;r=xml&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
 			<RegExp input="$INFO[tomato]" output="Tom" dest="10">
 				<expression>TomatoMeter</expression>
@@ -33,28 +33,12 @@
 			<RegExp input="$INFO[allcritics]" output="Aud" dest="10+">
 				<expression>Audience Score</expression>
 			</RegExp>
+			<RegExp input="$$1" output="default=&quot;true&quot;" dest="3">
+				<expression clear="yes">\|default$</expression>
+			</RegExp>
 			<expression>([0-9]{7})</expression>
 		</RegExp>
 	</GetRTRatingsById>
-
-	<!-- Get OMDBAPI URL from IMDb ID for ratings with new method as default -->
-	<GetRTRatingsByIdAsDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url function=&quot;ParseRT$$10NewDef&quot; cache=&quot;\1-omdbapi.html&quot;&gt;http://www.omdbapi.com/?i=tt\1&amp;apikey=$INFO[omdbapikey]&amp;r=xml&amp;tomatoes=true&lt;/url&gt;&lt;/details&gt;" dest="5">
-			<RegExp input="$INFO[tomato]" output="Tom" dest="10">
-				<expression>TomatoMeter</expression>
-			</RegExp>
-			<RegExp input="$INFO[tomato]" output="Ave" dest="10">
-				<expression>Average Rating</expression>
-			</RegExp>
-			<RegExp input="$INFO[allcritics]" output="All" dest="10+">
-				<expression>All Critics</expression>
-			</RegExp>
-			<RegExp input="$INFO[allcritics]" output="Aud" dest="10+">
-				<expression>Audience Score</expression>
-			</RegExp>
-			<expression>([0-9]{7})</expression>
-		</RegExp>
-	</GetRTRatingsByIdAsDef>
 
 	<!-- TomatoMeter from All Critics -->
 	<ParseRTTomAll dest="5">
@@ -86,59 +70,31 @@
 
 	<!-- TomatoMeter from All Critics with new format -->
 	<ParseRTTomAllNew dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallcritics&quot; max=&quot;100&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallcritics&quot; max=&quot;100&quot; $$3&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1">tomatoMeter=&quot;([^&quot;]+)&quot;.*?tomatoReviews=&quot;([^&quot;]+)</expression>
 		</RegExp>
 	</ParseRTTomAllNew>
 
 	<!-- TomatoMeter from Audience with new format -->
 	<ParseRTTomAudNew dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallaudience&quot; max=&quot;100&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallaudience&quot; max=&quot;100&quot; $$3&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1">tomatoUserMeter=&quot;([^&quot;]+)&quot;.*?tomatoUserReviews=&quot;([^&quot;]+)</expression>
 		</RegExp>
 	</ParseRTTomAudNew>
 
 	<!-- Average Rating from All Critics with new format -->
 	<ParseRTAveAllNew dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgcritics&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgcritics&quot; $$3&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1">tomatoRating=&quot;([^&quot;]+)&quot;.*?tomatoReviews=&quot;([^&quot;]+)</expression>
 		</RegExp>
 	</ParseRTAveAllNew>
 
 	<!-- Average Rating from Audience with new format-->
 	<ParseRTAveAudNew dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgaudience&quot; max=&quot;5&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgaudience&quot; max=&quot;5&quot; $$3&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
 			<expression noclean="1">tomatoUserRating=&quot;([^&quot;]+)&quot;.*?tomatoUserReviews=&quot;([^&quot;]+)</expression>
 		</RegExp>
 	</ParseRTAveAudNew>
-
-	<!-- TomatoMeter from All Critics with new format as default -->
-	<ParseRTTomAllNewDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallcritics&quot; default=&quot;true&quot; max=&quot;100&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">tomatoMeter=&quot;([^&quot;]+)&quot;.*?tomatoReviews=&quot;([^&quot;]+)</expression>
-		</RegExp>
-	</ParseRTTomAllNewDef>
-
-	<!-- TomatoMeter from Audience with new format as default -->
-	<ParseRTTomAudNewDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometerallaudience&quot; default=&quot;true&quot; max=&quot;100&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">tomatoUserMeter=&quot;([^&quot;]+)&quot;.*?tomatoUserReviews=&quot;([^&quot;]+)</expression>
-		</RegExp>
-	</ParseRTTomAudNewDef>
-
-	<!-- Average Rating from All Critics with new format as default -->
-	<ParseRTAveAllNewDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgcritics&quot; default=&quot;true&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">tomatoRating=&quot;([^&quot;]+)&quot;.*?tomatoReviews=&quot;([^&quot;]+)</expression>
-		</RegExp>
-	</ParseRTAveAllNewDef>
-
-	<!-- Average Rating from Audience with new format as default -->
-	<ParseRTAveAudNewDef dest="5">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;tomatometeravgaudience&quot; default=&quot;true&quot; max=&quot;5&quot;&gt;&lt;value&gt;\1&lt;/value&gt;&lt;votes&gt;\2&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
-			<expression noclean="1">tomatoUserRating=&quot;([^&quot;]+)&quot;.*?tomatoUserReviews=&quot;([^&quot;]+)</expression>
-		</RegExp>
-	</ParseRTAveAudNewDef>
 
 	<!-- Critics' Consensus -->
 	<GetRTOutlineById dest="5">

--- a/metadata.common.themoviedb.org/addon.xml
+++ b/metadata.common.themoviedb.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.themoviedb.org"
        name="The Movie Database Scraper Library"
-       version="2.17.5"
+       version="2.17.6"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.common.themoviedb.org/tmdb.xml
+++ b/metadata.common.themoviedb.org/tmdb.xml
@@ -324,16 +324,19 @@
 		</RegExp>
 	</ParseTMDBRating>
 
-	<GetTMDBRatingsByIdChain dest="4">
+	<GetTMDBRatingsByIdChain dest="4" clearbuffers="no">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
 			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBRatings&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=ecbc86c92da237cb9faff6d3ddc4be6d&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
-				<expression />
+				<expression noclean="1">^((tt)?\d+)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="default=&quot;true&quot;" dest="3">
+				<expression clear="yes">\|default$</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</GetTMDBRatingsByIdChain>
 	<ParseTMDBRatings dest="5">
-		<RegExp input="$$2" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot;&gt;\1&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
+		<RegExp input="$$2" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot; $$3&gt;\1&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
 			<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="2">
 				<expression noclean="1">&quot;vote_average&quot;:([^,]*),&quot;</expression>
 			</RegExp>
@@ -343,26 +346,6 @@
 			<expression noclean="1" />
 		</RegExp>
 	</ParseTMDBRatings>
-
-	<GetTMDBRatingsByIdAsDefChain dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBRatingsAsDef&quot; cache=&quot;tmdb-$INFO[language]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=ecbc86c92da237cb9faff6d3ddc4be6d&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="5">
-				<expression />
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetTMDBRatingsByIdAsDefChain>
-	<ParseTMDBRatingsAsDef dest="5">
-		<RegExp input="$$2" output="&lt;details&gt;&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot; default=&quot;true&quot;&gt;\1&lt;/rating&gt;&lt;/ratings&gt;&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="2">
-				<expression noclean="1">&quot;vote_average&quot;:([^,]*),&quot;</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="2+">
-				<expression noclean="1">&quot;vote_count&quot;:([0-9]+)</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseTMDBRatingsAsDef>
 
 	<GetTMDBStudioByIdChain dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">


### PR DESCRIPTION
This is an update and streamlining of the new code for ratings in the common libraries.  I didn't see any other scrapers using the current code, so I felt it safe to change it.

Instead of having two near-identical (pairs of) functions differing only by the inclusion of the default="true", there's now just one, which you either chain with just the id e.g.:
`<chain function="GetIMDBRatingsById">tt2294449</chain>` for non-default rating.
Or with the addition of "|default" for the default ratings, e.g.:
`<chain function="GetMetaCriticRatingsById">tt2294449|default</chain>`

As you'll see in the next PR, this can all be handled in a single RegExp (per rating) in the Universal scraper, so it results in no major code increase. The tvdb scraper is slightly more complicated, but not by much.

I also changed the metacritic ratings code to pull from the criticreviews page on imdb instead of the main page, as that page also includes the number of reviewers (i.e. the "votes").

@olympia, @phate89, @Razzeee to check, thanks.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
