### PR TITLE
[metadata.themoviedb.org] updated to v5.0.3

### DIFF
--- a/metadata.themoviedb.org/addon.xml
+++ b/metadata.themoviedb.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org"
        name="The Movie Database"
-       version="5.0.2"
+       version="5.0.3"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.themoviedb.org/changelog.txt
+++ b/metadata.themoviedb.org/changelog.txt
@@ -1,3 +1,6 @@
+[B]5.0.3[/B]
+- changed: made imdb uniqueid default when available
+
 [B]5.0.2[/B]
 - changed: made tmdb uniqueid consistent with documentation
 

--- a/metadata.themoviedb.org/tmdb.xml
+++ b/metadata.themoviedb.org/tmdb.xml
@@ -44,13 +44,13 @@
 	</GetSearchResults>
 	<GetDetails dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;$$2&lt;/uniqueid&gt;" dest="5">
-				<expression/>
-			</RegExp>
 			<RegExp input="$$1" output="\1" dest="11">
 				<expression clear="yes" noclean="1">&quot;id&quot;:[0-9]*,&quot;imdb_id&quot;:&quot;([^&quot;]*)</expression>
 			</RegExp>
-			<RegExp input="$$11" output="&lt;uniqueid type=&quot;imdb&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+			<RegExp input="$$11|default=&quot;true&quot;" output="&lt;uniqueid type=&quot;tmdb&quot; \1&gt;$$2&lt;/uniqueid&gt;" dest="5">
+				<expression>^\|(default=&quot;true&quot;)|tt[0-9]+</expression>
+			</RegExp>
+			<RegExp input="$$11" output="&lt;uniqueid type=&quot;imdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="9">


### PR DESCRIPTION
Makes themoviedb scraper save the imdb uniqueid as default (when available), as per [the discussion](https://github.com/xbmc/repo-scrapers/commit/9dbe28fa7dbe23e6c0288d93b2fbcb620c0adc82#comments).
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

