### PR TITLE
[metadata.universal] Add language filters to additional fanart.tv media types

### DIFF
--- a/metadata.universal/addon.xml
+++ b/metadata.universal/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.universal"
        name="Universal Movie Scraper"
-       version="5.2.3"
+       version="5.2.4"
        provider-name="Olympia, Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.universal/changelog.txt
+++ b/metadata.universal/changelog.txt
@@ -1,3 +1,6 @@
+[B]5.2.4[/B]
+- added: language filters for additional fanart.tv resource types
+
 [B]5.2.3[/B]
 - fixed: won't find TMDb title without year under some circumstances
 

--- a/metadata.universal/universal.xml
+++ b/metadata.universal/universal.xml
@@ -287,19 +287,19 @@
 			<RegExp conditional="fanarttvfanart" input="$$2" output="&lt;chain function=&quot;GetFanartTvFanartByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="fanarttvclearlogo" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieClearlogoByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="fanarttvclearlogo" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieClearlogoByIdChain&quot;&gt;$$2::$INFO[fanarttvposterlanguage]&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="fanarttvmoviebanner" input="$$2" output="&lt;chain function=&quot;GetFanartTvMoviebannerByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="fanarttvmoviebanner" input="$$2" output="&lt;chain function=&quot;GetFanartTvMoviebannerByIdChain&quot;&gt;$$2::$INFO[fanarttvposterlanguage]&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="fanarttvmovielandscape" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieLandscapeByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="fanarttvmovielandscape" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieLandscapeByIdChain&quot;&gt;$$2::$INFO[fanarttvposterlanguage]&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="fanarttvclearart" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieClearartByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="fanarttvclearart" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieClearartByIdChain&quot;&gt;$$2::$INFO[fanarttvposterlanguage]&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp conditional="fanarttvmoviediscart" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieDiscartByIdChain&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="fanarttvmoviediscart" input="$$2" output="&lt;chain function=&quot;GetFanartTvMovieDiscartByIdChain&quot;&gt;$$2::$INFO[fanarttvposterlanguage]&lt;/chain&gt;" dest="5+">
 				<expression/>
 			</RegExp>
 			<RegExp conditional="fanart" input="$$2" output="&lt;chain function=&quot;GetTMDBFanartByIdChain&quot;&gt;$$2::$INFO[tmdbthumblanguage]&lt;/chain&gt;" dest="5+">


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
To avoid foreign-language image downloads for media types that commonly
contain localized text, language filters are added to the following
sections:

- GetFanartTvMoviebannerByIdChain
- GetFanartTvMovieClearartByIdChain
- GetFanartTvMovieClearlogoByIdChain
- GetFanartTvMovieDiscartByIdChain
- GetFanartTvMovieLandscapeByIdChain

I did not create a new setting to control the language of each media type individually, but re-used the Poster language, I think this is always what users expect in any case.

This is the first time I've worked on these XML scrapers so a close review would be appreciated.

Depends on https://github.com/xbmc/repo-scrapers/pull/73
Fixes https://trac.kodi.tv/ticket/17854

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
