### PR TITLE
[metadata.tvdb.com] updated to v3.0.8

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.7"
+       version="3.0.8"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.8[/B]
+- Fixed: Character encoding fixes
+
 [B]3.0.7[/B]
 - Fixed: Episode list changes
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -87,6 +87,9 @@
 		<RegExp input="$$1" output="&lt;series&gt;&lt;id&gt;\3&lt;/id&gt;&lt;seriesName&gt;\4&lt;/seriesName&gt;&lt;aliases&gt;\1&lt;/aliases&gt;&lt;firstAired&gt;\2&lt;/firstAired&gt;&lt;/series&gt;" dest="4">
 			<expression repeat="yes" fixchars="1,4">"aliases":\s*?\[([^]]*)\],\s*?"banner":\s*?"[^"]*",\s*?"firstAired":\s*?"([^"]*)",\s*?"id":\s*?(\d+),\s*?"network":\s*?"[^"]*",\s*?"overview":\s*?(?:"[^}]*"|null),\s*?"seriesName":\s*?"([^}]*)",\s*?"slug":\s*?"[^"]*"</expression>
 		</RegExp>
+		<RegExp input="$$4" output="\1" dest="4">
+			<expression noclean="1" fixchars="1"/>
+		</RegExp>
 		<RegExp input="" output="" dest="6">
 			<expression/>
 		</RegExp>
@@ -237,7 +240,7 @@
 			<RegExp input="$$1" output="&lt;episodeguide&gt;&lt;url post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:\1}|Content-Type=application/json&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
 				<expression noclean="1">"id":\s*?(\d+),</expression>
 			</RegExp>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetDetails>
 	<GetFallbackDetails dest="3" clearbuffers="no">
@@ -260,7 +263,7 @@
 				</RegExp>
 				<expression>missingplot</expression>
 			</RegExp>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetFallbackDetails>
 	<GetActors dest="3" clearbuffers="no">
@@ -276,7 +279,7 @@
 			<RegExp input="$$1" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;/actor&gt;" dest="5+">
 				<expression repeat="yes" fixchars="1,2">"name":\s*?"([^}]+)",\s*?"role":\s*?"([^}]+)",\s*?"sortOrder":\s*?(\d+),\s*?"image":\s*?(?:""|null),</expression>
 			</RegExp>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</ParseActors>
 	<GetArt dest="3" clearbuffers="no">
@@ -443,7 +446,7 @@
 			<RegExp input="$$2" output="https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:\1}|Content-Type=application/json" dest="2">
 				<expression>http://(?:www\.)?thetvdb\.com/api/.+/series/(\d+)/all/</expression>
 			</RegExp>
-		<expression noclean="1"/>
+		<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetEpisodeList>
 	<GetEpisodeListAuth dest="3" clearbuffers="no">
@@ -483,7 +486,7 @@
 
 				</xsl:stylesheet>
 			</XSLT>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetEpisodeListAuth>
 	<LoadEpisodeList dest="4" clearbuffers="no">
@@ -771,7 +774,7 @@
 				</RegExp>
 				<expression>(?!^\Q$INFO[fallbacklanguage]\E$)</expression>
 			</RegExp>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetEpisodeDetailsAuth>
 	<GetFallbackEpisodeDetails dest="3" clearbuffers="no">
@@ -797,7 +800,7 @@
 			<RegExp input="$$10" output="&lt;Episode&gt;\1&lt;/Episode&gt;" dest="13+">
 				<expression noclean="1"/>
 			</RegExp>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetFallbackEpisodeDetails>
 	<ParseEpisodeDetails dest="4" clearbuffers="no">		
@@ -1099,7 +1102,7 @@
 
 				</xsl:stylesheet>
 			</XSLT>
-			<expression noclean="1"/>
+			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</ParseEpisodeDetails>
 </scraper>


### PR DESCRIPTION
### Description
Fix (hopefully) for tvdb issues with apostrophes.  

I think some double encoding must be going on, because the titles and such are fixchar'd in the scraper once already.

Krypton version.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
