### PR TITLE
[metadata.tvdb.com] updated to v3.0.9

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.8"
+       version="3.0.9"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.9[/B]
+- Fixed: Character encoding fixes (part 2)
+
 [B]3.0.8[/B]
 - Fixed: Character encoding fixes
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -87,9 +87,6 @@
 		<RegExp input="$$1" output="&lt;series&gt;&lt;id&gt;\3&lt;/id&gt;&lt;seriesName&gt;\4&lt;/seriesName&gt;&lt;aliases&gt;\1&lt;/aliases&gt;&lt;firstAired&gt;\2&lt;/firstAired&gt;&lt;/series&gt;" dest="4">
 			<expression repeat="yes" fixchars="1,4">"aliases":\s*?\[([^]]*)\],\s*?"banner":\s*?"[^"]*",\s*?"firstAired":\s*?"([^"]*)",\s*?"id":\s*?(\d+),\s*?"network":\s*?"[^"]*",\s*?"overview":\s*?(?:"[^}]*"|null),\s*?"seriesName":\s*?"([^}]*)",\s*?"slug":\s*?"[^"]*"</expression>
 		</RegExp>
-		<RegExp input="$$4" output="\1" dest="4">
-			<expression noclean="1" fixchars="1"/>
-		</RegExp>
 		<RegExp input="" output="" dest="6">
 			<expression/>
 		</RegExp>
@@ -148,6 +145,9 @@
 
 			</xsl:stylesheet>
 		</XSLT>
+		<RegExp input="$$6" output="\1" dest="6">
+			<expression noclean="1" fixchars="1"/>
+		</RegExp>
 	</GetSearchResultsAuth>
 
 	<!-- input : $$1=series html -->


### PR DESCRIPTION
### Description
Placed the fixchar too early in the search results, which, it turns out, could break the xml before being passed to the xslt.  
(Probably due to ampersands in the search results.)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
