### PR TITLE
[metadata.tvdb.com] updated to v3.0.10

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.9"
+       version="3.0.10"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.10[/B]
+- Fixed: Use the year in the title as fallback when no firstAired field, to reduce mismatches
+
 [B]3.0.9[/B]
 - Fixed: Character encoding fixes (part 2)
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -84,8 +84,8 @@
 	<!-- input : $$2=search url -->
 	<!-- output: <results><entity><title>*</title><year>*</year><language>*</language><url>*</url><id>*</id></entity>*</results> -->
 	<GetSearchResultsAuth dest="6" clearbuffers="no">
-		<RegExp input="$$1" output="&lt;series&gt;&lt;id&gt;\3&lt;/id&gt;&lt;seriesName&gt;\4&lt;/seriesName&gt;&lt;aliases&gt;\1&lt;/aliases&gt;&lt;firstAired&gt;\2&lt;/firstAired&gt;&lt;/series&gt;" dest="4">
-			<expression repeat="yes" fixchars="1,4">"aliases":\s*?\[([^]]*)\],\s*?"banner":\s*?"[^"]*",\s*?"firstAired":\s*?"([^"]*)",\s*?"id":\s*?(\d+),\s*?"network":\s*?"[^"]*",\s*?"overview":\s*?(?:"[^}]*"|null),\s*?"seriesName":\s*?"([^}]*)",\s*?"slug":\s*?"[^"]*"</expression>
+		<RegExp input="$$1" output="&lt;series&gt;&lt;id&gt;\3&lt;/id&gt;&lt;seriesName&gt;\4&lt;/seriesName&gt;&lt;aliases&gt;\1&lt;/aliases&gt;&lt;firstAired&gt;\2&lt;/firstAired&gt;&lt;year&gt;\5&lt;/year&gt;&lt;/series&gt;" dest="4">
+			<expression repeat="yes" fixchars="1,4">"aliases":\s*?\[([^]]*)\],\s*?"banner":\s*?"[^"]*",\s*?"firstAired":\s*?"([^"]*)",\s*?"id":\s*?(\d+),\s*?"network":\s*?"[^"]*",\s*?"overview":\s*?(?:"[^}]*"|null),\s*?"seriesName":\s*?"([^}]*?(?:\(([0-9]{4})\))?)",\s*?"slug":\s*?"[^"]*"</expression>
 		</RegExp>
 		<RegExp input="" output="" dest="6">
 			<expression/>
@@ -136,7 +136,12 @@
 					<xsl:param name="title"/>					
 					<entity>
 						<title><xsl:value-of select="$title"/></title>
-						<year><xsl:value-of select="substring(firstAired,1,4)"/></year>
+						<year>
+							<xsl:choose>
+								<xsl:when test="firstAired!=''"><xsl:value-of select="substring(firstAired,1,4)"/></xsl:when>
+								<xsl:otherwise><xsl:value-of select="year"/></xsl:otherwise>
+							</xsl:choose>
+						</year>
 						<language>$$16</language>
 						<url><xsl:attribute name="cache"><xsl:value-of select="id"/>-$INFO[language].json</xsl:attribute>https://api.thetvdb.com/series/<xsl:value-of select="id"/>|Authorization=Bearer%20$$19&amp;accept-language=$INFO[language]</url>
 						<id><xsl:value-of select="id"/></id>


### PR DESCRIPTION
### Description
(Sort-of) Fix for the missing firstAired field from tvdb causing mismatches.
It captures the year from the title, if there is one, and uses that as fallback for the firstAired field in the search results.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

