### PR TITLE
[metadata.tvdb.com] updated to v3.0.11

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.10"
+       version="3.0.11"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.11[/B]
+- Fixed: Use first aired episode date when firstAired field is missing (thx to Smeulf)
+
 [B]3.0.10[/B]
 - Fixed: Use the year in the title as fallback when no firstAired field, to reduce mismatches
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -180,7 +180,10 @@
 				<expression clear="yes">"seriesName":\s*?null,\s*?"aliases"</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;premiered&gt;\1&lt;/premiered&gt;" dest="4+">
-				<expression>"firstAired":\s*?"([^"]*)",</expression>
+				<expression>"firstAired":\s*?"([^"]+)",</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;url function=&quot;GetPremieredFromFirstEp&quot;&gt;https://api.thetvdb.com/series/$$2/episodes/query?airedSeason=1&amp;airedEpisode=1|Authorization=Bearer%20$$19&amp;amp;accept-language=$INFO[language]&lt;/url&gt;" dest="4+">
+				<expression>"firstAired":\s*?"",</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;runtime&gt;\1&lt;/runtime&gt;" dest="4+">
 				<expression>"runtime":\s*?"([^"]*)",</expression>
@@ -248,6 +251,14 @@
 			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</GetDetails>
+	<GetPremieredFromFirstEp dest="3" clearbuffers="no">
+		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;premiered&gt;\1&lt;/premiered&gt;" dest="4">
+				<expression clear="yes">"firstAired":\s*?"([^"]+)"</expression>
+			</RegExp>
+			<expression noclean="1"/>
+		</RegExp>
+	</GetPremieredFromFirstEp>
 	<GetFallbackDetails dest="3" clearbuffers="no">
 		<RegExp input="$$4" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<RegExp input="$$14" output="$$5" dest="4">


### PR DESCRIPTION
### Description
Quick fix for missing FirstAired date for recent series.

With thanks to forum user Smeulf for pointing out the easy way to do it, rather than the horribly complicated way I suggested and wasn't willing to do.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
