### PR TITLE
[metadata.tvdb.com] updated to v3.0.12

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.11"
+       version="3.0.12"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.12[/B]
+- Fixed: DVD and Absolute episode ordering fixes
+
 [B]3.0.11[/B]
 - Fixed: Use first aired episode date when firstAired field is missing (thx to Smeulf)
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -565,7 +565,7 @@
 					xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 				<xsl:output omit-xml-declaration="yes" indent="yes"/>
 				<xsl:strip-space elements="*"/>
-				<xsl:key name="EpisodesByDVDnumber" match="Episode" use="concat(DVD_season,',',substring-before(DVD_episodenumber,'.'))"/>
+				<xsl:key name="EpisodesByDVDnumber" match="Episode" use="concat(DVD_season,',',substring-before(concat(DVD_episodenumber,'.'),'.'))"/>
 				<xsl:key name="EpisodesBySeason" match="Episode" use="SeasonNumber"/>
 				<xsl:variable name="title-divider" select="' / '"/>
 
@@ -591,10 +591,10 @@
 						<xsl:choose>
 							<xsl:when test="'$INFO[dvdorder]'!='true'">
 								<xsl:choose>
-									<xsl:when test="('$INFO[absolutenumber]'='true') and ((SeasonNumber&gt;0) or (absolute_number!=''))">
+									<xsl:when test="('$INFO[absolutenumber]'='true') and ((SeasonNumber&gt;0) or ((absolute_number!='') and (absolute_number!=0)))">
 										<epnum>
 											<xsl:choose>
-												<xsl:when test="absolute_number!=''"><xsl:value-of select="absolute_number"/></xsl:when>
+												<xsl:when test="(absolute_number!='') and (absolute_number!=0)"><xsl:value-of select="absolute_number"/></xsl:when>
 												<xsl:otherwise><xsl:value-of select="substring-before(substring-after($SeasonCounts, concat('|S', SeasonNumber, '|')), '|') + EpisodeNumber"/></xsl:otherwise>
 											</xsl:choose>
 										</epnum>
@@ -606,12 +606,12 @@
 							</xsl:when>
 							<xsl:otherwise>
 								<xsl:choose>
-									<xsl:when test="(DVD_episodenumber!='') and (DVD_season!='')">
+									<xsl:when test="((DVD_episodenumber!='') and (DVD_season!='')) and ((DVD_episodenumber!=0) or (DVD_season!=0))">
 										<epnum><xsl:value-of select="DVD_episodenumber"/></epnum>
 										<season><xsl:value-of select="DVD_season"/></season>
 									</xsl:when>
 									<xsl:otherwise>
-										<epnum><xsl:value-of select="EpisodeNumber"/><xsl:if test="key('EpisodesByDVDnumber', concat(SeasonNumber,',',EpisodeNumber))">.<xsl:value-of select="count(key('EpisodesByDVDnumber', concat(SeasonNumber,',',EpisodeNumber))[(DVD_episodenumber!='') and (substring-after(DVD_episodenumber,'.')!='0')])+1"/></xsl:if></epnum>
+										<epnum><xsl:value-of select="EpisodeNumber"/><xsl:if test="key('EpisodesByDVDnumber', concat(SeasonNumber,',',EpisodeNumber))">.<xsl:value-of select="count(key('EpisodesByDVDnumber', concat(SeasonNumber,',',EpisodeNumber))[(DVD_episodenumber!='') and number(substring-after(concat(DVD_episodenumber,'.0'),'.'))&gt;0])+1"/></xsl:if></epnum>
 										<season><xsl:value-of select="SeasonNumber"/></season>
 									</xsl:otherwise>
 								</xsl:choose>
@@ -731,7 +731,7 @@
 				<expression>"dvdSeason":\s*?(?:(\d+)|null),</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;dvdEpisodeNumber&gt;\1&lt;/dvdEpisodeNumber&gt;" dest="10+">
-				<expression>"dvdEpisodeNumber":\s*?(?:(\d+)|null),</expression>
+				<expression>"dvdEpisodeNumber":\s*?(?:([\d\.]+)|null),</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;absoluteNumber&gt;\1&lt;/absoluteNumber&gt;" dest="10+">
 				<expression>"absoluteNumber":\s*?(?:(\d+)|null),</expression>
@@ -829,7 +829,7 @@
 						xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 					<xsl:output indent="yes"/>
 					<xsl:strip-space elements="*"/>
-					<xsl:key name="EpisodesByDVDnumber" match="current/Episode" use="concat(dvdSeason,',',substring-before(dvdEpisodeNumber,'.'))"/>
+					<xsl:key name="EpisodesByDVDnumber" match="current/Episode" use="concat(dvdSeason,',',substring-before(concat(dvdEpisodeNumber,'.'),'.'))"/>
 					<xsl:variable name="SeasonCounts">
 						<xsl:if test="'$INFO[absolutenumber]'='true'">$$12</xsl:if>
 					</xsl:variable>
@@ -891,10 +891,10 @@
 							<xsl:choose>
 								<xsl:when test="'$INFO[dvdorder]'!='true'">
 									<xsl:choose>
-										<xsl:when test="('$INFO[absolutenumber]'='true') and (($FirstEpisode/airedSeason&gt;0) or ($FirstEpisode/absoluteNumber!=''))">
+										<xsl:when test="('$INFO[absolutenumber]'='true') and (($FirstEpisode/airedSeason&gt;0) or (($FirstEpisode/absoluteNumber!='') and ($FirstEpisode/absoluteNumber!=0)))">
 											<episode>
 												<xsl:choose>
-													<xsl:when test="$FirstEpisode/absoluteNumber!=''"><xsl:value-of select="$FirstEpisode/absoluteNumber"/></xsl:when>
+													<xsl:when test="($FirstEpisode/absoluteNumber!='') and ($FirstEpisode/absoluteNumber!=0)"><xsl:value-of select="$FirstEpisode/absoluteNumber"/></xsl:when>
 													<xsl:otherwise><xsl:value-of select="substring-before(substring-after($SeasonCounts, concat('|S', $FirstEpisode/airedSeason, '|')), '|') + $FirstEpisode/airedEpisodeNumber"/></xsl:otherwise>
 												</xsl:choose>
 											</episode>
@@ -912,8 +912,8 @@
 								</xsl:when>
 								<xsl:otherwise>
 									<xsl:choose>
-										<xsl:when test="($FirstEpisode/dvdEpisodeNumber='') or ($FirstEpisode/dvdSeason='')">
-											<episode><xsl:value-of select="$FirstEpisode/airedEpisodeNumber"/><xsl:if test="key('EpisodesByDVDnumber', concat($FirstEpisode/airedSeason,',',$FirstEpisode/airedEpisodeNumber))">.<xsl:value-of select="count(key('EpisodesByDVDnumber', concat($FirstEpisode/airedSeason,',',$FirstEpisode/airedEpisodeNumber))[(dvdEpisodeNumber!='') and (substring-after(dvdEpisodeNumber,'.')!='0')])+1"/></xsl:if></episode>
+										<xsl:when test="(($FirstEpisode/dvdEpisodeNumber='') or ($FirstEpisode/dvdSeason='')) or (($FirstEpisode/dvdEpisodeNumber=0) and ($FirstEpisode/dvdSeason=0))">
+											<episode><xsl:value-of select="$FirstEpisode/airedEpisodeNumber"/><xsl:if test="key('EpisodesByDVDnumber', concat($FirstEpisode/airedSeason,',',$FirstEpisode/airedEpisodeNumber))">.<xsl:value-of select="count(key('EpisodesByDVDnumber', concat($FirstEpisode/airedSeason,',',$FirstEpisode/airedEpisodeNumber))[(dvdEpisodeNumber!='') and number(substring-after(concat(dvdEpisodeNumber,'.0'),'.'))&gt;0])+1"/></xsl:if></episode>
 											<season><xsl:value-of select="$FirstEpisode/airedSeason"/></season>
 										</xsl:when>
 										<xsl:otherwise>
@@ -1121,4 +1121,20 @@
 			<expression noclean="1" fixchars="1"/>
 		</RegExp>
 	</ParseEpisodeDetails>
+	<GetIMDBRatingsById dest="5" clearbuffers="no">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-main.html&quot; function=&quot;ParseIMDBRatings&quot;&gt;http://www.imdb.com/title/\1/|accept-language=en-us&lt;/url&gt;&lt;/details&gt;" dest="5">
+			<expression noclean="1">^(tt\d+)</expression>
+		</RegExp>
+		<RegExp input="$$1" output="default=&quot;true&quot;" dest="3">
+			<expression clear="yes">\|default$</expression>
+		</RegExp>
+	</GetIMDBRatingsById>
+	<ParseIMDBRatings dest="5" clearbuffers="no">
+		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;ratings&gt;&lt;rating name=&quot;imdb&quot; $$3&gt;&lt;value&gt;\2&lt;/value&gt;&lt;votes&gt;\1&lt;/votes&gt;&lt;/rating&gt;&lt;/ratings&gt;" dest="2">
+				<expression>&quot;ratingCount&quot;:\s([0-9,]+),\s*&quot;bestRating&quot;:\s&quot;[^&quot;]*&quot;,\s*&quot;worstRating&quot;:\s&quot;[^&quot;]*&quot;,\s*&quot;ratingValue&quot;:\s&quot;([0-9.]+)</expression>
+			</RegExp>
+			<expression noclean="1" />
+		</RegExp>
+	</ParseIMDBRatings>
 </scraper>


### PR DESCRIPTION
### Description
theTVDb API has started filling in empty DVD and Absolute season and episode numbers with zeros, rather than leaving them as NULL, which prevents the scraper from using fallbacks.

While fixing that, I noticed a few other mistakes in the handling of DVD and Absolute orders, chief among them being that using IMDB ratings would clear buffers that need to remain while adding multiple episodes, so I had to include those functions in the scraper to add the `clearbuffers="no"` to ParseIMDBRatings .  I could have just added it to the common library, but was fearful of unintended consequences for other scrapers.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0