### PR TITLE
[metadata.tvdb.com] updated to v3.0.13

### DIFF
--- a/metadata.tvdb.com/addon.xml
+++ b/metadata.tvdb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="3.0.12"
+       version="3.0.13"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvdb.com/changelog.txt
+++ b/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.0.13[/B]
+- Added: Support slug URLs in nfo files
+
 [B]3.0.12[/B]
 - Fixed: DVD and Absolute episode ordering fixes
 

--- a/metadata.tvdb.com/tvdb.xml
+++ b/metadata.tvdb.com/tvdb.xml
@@ -11,8 +11,14 @@
 		<RegExp input="$$1" output="tt\1" dest="7">
 			<expression>imdb\....?/title\?([0-9]*)</expression>
 		</RegExp>
-		<RegExp input="$$7" output="&lt;details&gt;&lt;url function=&quot;GetTVDBId&quot; post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;}|Content-Type=application/json&lt;/url&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$7" output="&lt;details&gt;&lt;url function=&quot;GetTVDBIdByIMDBId&quot; post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;}|Content-Type=application/json&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<expression>(?!^$)</expression>
+		</RegExp>
+		<RegExp input="$$1" output="\1" dest="7">
+			<expression clear="yes">https?://(?:www\.)?thetvdb.com/series/([^\s]+)</expression>
+		</RegExp>
+		<RegExp input="$$7" output="&lt;details&gt;&lt;url function=&quot;GetTVDBIdBySlug&quot; post=&quot;yes&quot; cache=&quot;auth.json&quot;&gt;https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;}|Content-Type=application/json&lt;/url&gt;&lt;/details&gt;" dest="3">
+			<expression>(?!^$)(.*)</expression>
 		</RegExp>
 		<RegExp input="$$1" output="\1" dest="6">
 			<expression clear="yes">https?://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
@@ -22,23 +28,31 @@
 		</RegExp>
 	</NfoUrl>
 	<NfoUrlAuth dest="3" clearbuffers="no">
-		<RegExp input="$$19" output="&lt;details&gt;&lt;url cache=&quot;$$6-$INFO[language].xml&quot;&gt;https://api.thetvdb.com/series/$$6|Authorization=Bearer%20\1&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;id&gt;$$6&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$19" output="&lt;details&gt;&lt;url cache=&quot;$$6-$INFO[language].json&quot;&gt;https://api.thetvdb.com/series/$$6|Authorization=Bearer%20\1&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;id&gt;$$6&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<RegExp input="$$1" output="\1" dest="19">
 				<expression>"token":\s*?"(.*)"</expression>
 			</RegExp>
 		<expression noclean="1"/>
 		</RegExp>
 	</NfoUrlAuth>
-	<GetTVDBId dest="3" clearbuffers="no">
+	<GetTVDBIdByIMDBId dest="3" clearbuffers="no">
 		<RegExp input="$$19" output="&lt;details&gt;&lt;url function=&quot;GetTVDBIdAuth&quot; cache=&quot;search-$$7-$INFO[language].json&quot;&gt;https://api.thetvdb.com/search/series?imdbId=$$7|Authorization=Bearer%20\1&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3">
 			<RegExp input="$$1" output="\1" dest="19">
 				<expression>"token":\s*?"(.*)"</expression>
 			</RegExp>
 		<expression noclean="1"/>
 		</RegExp>
-	</GetTVDBId>
+	</GetTVDBIdByIMDBId>
+	<GetTVDBIdBySlug dest="3" clearbuffers="no">
+		<RegExp input="$$19" output="&lt;details&gt;&lt;url function=&quot;GetTVDBIdAuth&quot; cache=&quot;search-$$7-$INFO[language].json&quot;&gt;https://api.thetvdb.com/search/series?slug=$$7|Authorization=Bearer%20\1&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3">
+			<RegExp input="$$1" output="\1" dest="19">
+				<expression>"token":\s*?"(.*)"</expression>
+			</RegExp>
+		<expression noclean="1"/>
+		</RegExp>
+	</GetTVDBIdBySlug>
 	<GetTVDBIdAuth dest="3" clearbuffers="no">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;https://api.thetvdb.com/series/\1|Authorization=Bearer%20$$19&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].json&quot;&gt;https://api.thetvdb.com/series/\1|Authorization=Bearer%20$$19&amp;accept-language=$INFO[language]&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>"id":\s*?(\d+),</expression>
 		</RegExp>
 	</GetTVDBIdAuth>


### PR DESCRIPTION
### Description
This adds support for using the current slug-based URLs from thetvdb in nfo files.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
