### PR TITLE
[metadata.tvshows.themoviedb.org] updated to v3.1.0

### DIFF
--- a/metadata.tvshows.themoviedb.org/addon.xml
+++ b/metadata.tvshows.themoviedb.org/addon.xml
@@ -9,7 +9,8 @@
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows"
              language="en"
-             library="tmdb.xml"/>
+             library="tmdb.xml"
+             cachepersistence="00:15"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="bg">Сваля инф. за ТВ Сериали от TMDB</summary>
     <summary lang="cs">TMDb zdroj  dat k seriálům </summary>

--- a/metadata.tvshows.themoviedb.org/changelog.txt
+++ b/metadata.tvshows.themoviedb.org/changelog.txt
@@ -1,3 +1,9 @@
+[B]3.1.0[/B]
+- Changed: re-use season files to reduce number of API calls for episode details
+- Added: small cache persistence
+- Added: support for Episode Groups using nfo files
+- Added: named seasons support
+
 [B]3.0.6[/B]
 - Fixed: show overview
 

--- a/metadata.tvshows.themoviedb.org/tmdb.xml
+++ b/metadata.tvshows.themoviedb.org/tmdb.xml
@@ -20,6 +20,9 @@
 			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
 				<expression noclean="1">themoviedb\.org/tv/([0-9]+)</expression>
 			</RegExp>
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1|\2&lt;/id&gt;" dest="5">
+				<expression noclean="1">themoviedb\.org/tv/([0-9]+)[^\/]*/episode_group/([0-9a-f]+)</expression>
+			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</NfoUrl>
@@ -52,9 +55,12 @@
 			<expression noclean="1" />
 		</RegExp>
 	</GetSearchResults>
-
+	
 	<GetDetails dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
+			<RegExp input="$$2" output="\1" dest="10">
+				<expression>^([0-9]+)</expression>
+			</RegExp>
 			<RegExp input="$$1" output="\1" dest="7">
 				<expression fixchars="1">"original_name":"([^"]*)</expression>
 			</RegExp>
@@ -67,7 +73,7 @@
 			<RegExp input="$$7" output="&lt;originaltitle&gt;\1&lt;/originaltitle&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;id&gt;\1&lt;/id&gt;&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;id&gt;\1&lt;/id&gt;&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
 				<expression/>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;year&gt;\1&lt;/year&gt;" dest="5+">
@@ -93,7 +99,7 @@
 			</RegExp>
 			<RegExp input="$$7" output="&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot; default=&quot;true&quot;&gt;\1&lt;/rating&gt;&lt;/ratings&gt;" dest="5+">
 				<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="7">
-					<expression>&quot;vote_average&quot;:([^&quot;]*)</expression>
+					<expression>&quot;vote_average&quot;:([^,]*),</expression>
 				</RegExp>
 				<RegExp input="$$1" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="7+">
 					<expression>&quot;vote_count&quot;:([0-9]+)</expression>
@@ -103,7 +109,7 @@
 			<RegExp input="$$1" output="&lt;mpaa&gt;\1&lt;/mpaa&gt;" dest="5+">
 				<expression>&quot;rating&quot;:"([^"]*)"</expression>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;chain function=&quot;GetCast&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;chain function=&quot;GetCast&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<RegExp input="$$7" output="&lt;genre&gt;\1&lt;/genre&gt;" dest="5+">
@@ -119,7 +125,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$2-en.json&quot;&gt;http://api.themoviedb.org/3/tv/$$2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$10-en.json&quot;&gt;http://api.themoviedb.org/3/tv/$$10?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -133,23 +139,56 @@
 			<RegExp conditional="fanarttvart" input="$$19" output="&lt;chain function=&quot;GetFanartTvArt&quot;&gt;\1&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
-			<RegExp conditional="tmdbart" input="$$2" output="&lt;chain function=&quot;GetArt&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp conditional="tmdbart" input="$$10" output="&lt;chain function=&quot;GetArt&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
-			<RegExp input="$$3" output="&lt;episodeguide&gt;&lt;url cache=&quot;tmdb-$$2-$INFO[language].json&quot;&gt;\1&lt;/url&gt;&lt;/episodeguide&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;namedseason number=&quot;\2&quot;&gt;\1&lt;/namedseason&gt;" dest="5+">
+				<expression>"name":"([^}]+)","overview":[^}]*?"season_number":(0)\}</expression>
+			</RegExp>
+			<RegExp input="$$8" output="\1" dest="5+">
+				<RegExp input="$$1" output="&lt;namedseason number=&quot;\2&quot;&gt;\1&lt;/namedseason&gt;" dest="8">
+					<expression repeat="yes" fixchars="1">"name":"([^}]+)","overview":[^}]*?"season_number":(?!0})([0-9]+)}</expression>
+				</RegExp>
+				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupSeasonNames&quot; cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="8">
+					<expression>\|([0-9a-f]+)$</expression>
+				</RegExp>
+				<expression noclean="1"/>
+			</RegExp>
+			<RegExp input="$$2" output="&lt;url cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="12">
+				<expression clear="yes">\|([0-9a-f]+)$</expression>
+			</RegExp>
+			<RegExp input="$$3" output="&lt;episodeguide&gt;&lt;url cache=&quot;tmdb-$$10-$INFO[language].json&quot;&gt;\1&lt;/url&gt;$$12&lt;/episodeguide&gt;" dest="5+">
 				<expression>(.*)&amp;append</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</GetDetails>
 
+	<GetEpisodeGroupSeasonNames dest="3">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;namedseason number=&quot;\2&quot;&gt;\1&lt;/namedseason&gt;" dest="5">
+				<expression repeat="yes" fixchars="1">"name":"([^[\]]*?)","order":([0-9]+),"episodes"</expression>
+			</RegExp>
+			<expression noclean="1"/>
+		</RegExp>	
+	</GetEpisodeGroupSeasonNames>
+	
 	<GetEpisodeList clearbuffers="no" dest="3">
 		<RegExp input="$$4" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="3">
 			<RegExp input="$$1" output="\1" dest="5">
 				<expression>"id":([0-9]+),"in_production"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="4">
-				<expression repeat="yes">"season_number":([0-9]+)</expression>
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="4">
+				<expression clear="yes">"season_number":(0)}</expression>
+			</RegExp>
+			<RegExp input="$$9" output="\1" dest="4+">
+				<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="9">
+					<expression repeat="yes">"season_number":(?!0})([0-9]+)</expression>
+				</RegExp>
+				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupList&quot; cache=&quot;tmdb-$$5-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="9">
+					<expression>"id":"([0-9a-f]+)","name":"[^}]*","network"</expression>
+				</RegExp>
+				<expression noclean="1"/>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
@@ -159,23 +198,78 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression clear="yes">"season_number":([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-episode-s$$6e\3.json&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/$$6/episode/\3?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\3&lt;/id&gt;&lt;/episode&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-$$6.json&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/$$6?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\3&lt;/id&gt;&lt;/episode&gt;" dest="4">
 				<expression repeat="yes" clear="yes">"air_date":("([^"]+)"|null),"episode_number":([0-9]+),"id":[0-9]+,"name":"((?:[^"]|(?&lt;=\\)")*)",</expression>
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
 	</GetSeasonEpisodeList>
+	<GetEpisodeGroupList clearbuffers="no" dest="3">
+		<RegExp input="$$4" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetEpisodeGroupSeasonList&quot;&gt;\1&lt;/chain&gt;" dest="4">
+				<expression repeat="yes">"order":([0-9]+),"episodes":[^]]+\]</expression>
+			</RegExp>
+			<RegExp input="$$1" output="\1" dest="18">
+				<expression noclean="1"/>
+			</RegExp>		
+			<expression noclean="1"/>
+		</RegExp>
+	</GetEpisodeGroupList>
+	<GetEpisodeGroupSeasonList clearbuffers="no" dest="3">
+		<RegExp input="$$15" output="\1" dest="3">
+			<RegExp input="$$18" output="&lt;!-- Group name: \1 --&gt;" dest="4">
+				<expression>"name":"([^[\]{]+)","network":</expression>
+			</RegExp>	
+			<RegExp input="$$18" output="&lt;!-- Season name: \1 --&gt;" dest="4+">
+				<expression>"name":"([^[\]{]+)","order":$$1</expression>
+			</RegExp>
+			<RegExp input="$$18" output="\1" dest="6">
+				<expression>"order":$$1,"episodes":([^]]+)\]</expression>
+			</RegExp>	
+			<RegExp input="$$6" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\7&lt;/epnum&gt;&lt;season&gt;$$1&lt;/season&gt;&lt;url cache=&quot;tmdb-\6-$INFO[language]-season-\5.json&quot;&gt;http://api.themoviedb.org/3/tv/\6/season/\5?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\6|\5|\3&lt;/id&gt;&lt;/episode&gt;" dest="4+">
+				<expression repeat="yes">{"air_date":("([^"]+)"|null),"episode_number":([0-9]+),"id":[0-9]+,"name":"((?:[^"]|(?&lt;=\\)")*)",[^}]+"season_number":([0-9]+),"show_id":([0-9]+),[^}]+"order":([0-9]+)</expression>
+			</RegExp>	
+			<RegExp input="" output="" dest="15">
+				<expression/>
+			</RegExp>	
+			<XSLT input="&lt;episodeguide&gt;$$4&lt;/episodeguide&gt;" output="\1" dest="15">
+				<xsl:stylesheet version = "1.0"
+					xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+					<xsl:output omit-xml-declaration="yes" indent="yes"/>
+					<xsl:template match="node()|@*">
+						<xsl:copy>
+							<xsl:apply-templates select="@*" />
+							<xsl:apply-templates />
+						</xsl:copy>
+					</xsl:template>
+					<xsl:template match="epnum">
+						<epnum><xsl:value-of select=".+1"/></epnum>
+					</xsl:template>
+					<xsl:template match="id">
+						<id><xsl:value-of select="."/>|<xsl:value-of select="../season"/>|<xsl:value-of select="../epnum+1"/></id>
+					</xsl:template>								
+				</xsl:stylesheet>
+			</XSLT>
+			<expression noclean="1"/>
+		</RegExp>
+	</GetEpisodeGroupSeasonList>
 
-	<GetEpisodeDetails dest="3">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
+	<GetEpisodeDetails dest="4">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
+			<RegExp input="$$1" output="\1" dest="1">
+				<RegExp input="$$2" output="\1" dest="7">
+					<expression>^[0-9]+\|[0-9]+\|([0-9]+)</expression>
+				</RegExp>
+				<expression>({"air_date":"[^"]*","episode_number":$$7,"id":\d+,.+)</expression>
+			</RegExp>
+			<RegExp input="$$2" output="\1" dest="6">
+				<expression>^([0-9]+)\|</expression>
+			</RegExp>
 			<RegExp input="$$1" output="\1" dest="10">
 				<expression>"season_number":([0-9]+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="11">
 				<expression>"episode_number":([0-9]+)</expression>
-			</RegExp>
-			<RegExp input="$$2" output="\1" dest="6">
-				<expression>([0-9]+)\|</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression fixchars="1" clear="yes">"name":"([^\}]*?)","overview"</expression>
@@ -189,14 +283,14 @@
 				</RegExp>
 				<expression>^$</expression>
 			</RegExp>
-			<RegExp input="$$10|$$11" output="&lt;season&gt;\1&lt;/season&gt;&lt;episode&gt;\2&lt;/episode&gt;" dest="5+">
-				<expression>([0-9]+)\|([0-9]+)</expression>
+			<RegExp input="$$2" output="&lt;season&gt;\1&lt;/season&gt;&lt;episode&gt;\2&lt;/episode&gt;" dest="5+">
+				<expression>([0-9]+)\|([0-9]+)$</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;aired&gt;\1&lt;/aired&gt;" dest="5+">
 				<expression>"air_date":"([^"]*)"</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
-				<expression>"id":([0-9]+),"production_code"</expression>
+				<expression>"id":([0-9]+),"name"</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;ratings&gt;&lt;rating name=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/rating&gt;&lt;/ratings&gt;" dest="5+">
 				<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="7">
@@ -208,7 +302,7 @@
 				<expression noclean="1">(.+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="9">
-				<expression clear="yes" fixchars="1">"overview":"([^\{]+?)","id"</expression>
+				<expression clear="yes" fixchars="1">"overview":"([^\{]+?)","production_code"</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="5+">
 				<expression>(.+)</expression>
@@ -228,10 +322,10 @@
 			<RegExp input="$$7" output="&lt;credits&gt;\1&lt;/credits&gt;" dest="5+">
 				<expression repeat="yes" fixchars="1">"name":"([^"]*)","department":"Writing"</expression>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;chain function=&quot;GetCast&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp input="" output="&lt;chain function=&quot;GetCast&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
-			<RegExp input="$$2" output="&lt;chain function=&quot;GetEpisodeArt&quot;&gt;$$2&lt;/chain&gt;" dest="5+">
+			<RegExp input="" output="&lt;chain function=&quot;GetEpisodeArt&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1"/>
@@ -241,7 +335,7 @@
 	<ParseFallbackTMDBPlot dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
 			<RegExp input="$$1" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="5">
-				<expression clear="yes" fixchars="1">original_name&quot;:&quot;[^&quot;]*&quot;,"overview":"([^\{]*?)","(?:id|popularity)"</expression>
+				<expression clear="yes" fixchars="1">overview":"([^\{]*?)","(?:id|popularity)"</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -265,16 +359,19 @@
 		</RegExp>
 	</ParseTMDBBaseImageURL>
 
-	<GetCast dest="3">
+	<GetCast dest="3" clearbuffers="no">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
 			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
-				<expression>^([0-9]+)$</expression> />
+				<expression>^([0-9]+)$</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2/episode/\3?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
-				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression> />
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+				<RegExp input="$$1" output="\1" dest="11">
+					<expression>^[0-9]+\|[0-9]+\|([0-9]+)$</expression>
+				</RegExp>
+				<expression>^([0-9]+)\|([0-9]+)\|[0-9]+$</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -290,14 +387,17 @@
 			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;/actor&gt;" dest="5+">
 				<expression repeat="yes" fixchars="1,2">"character":"((?:[^"]|(?&lt;=\\)")*)","credit_id":"[^"]*","id":[0-9]*,"name":"([^"]*)","gender":[^,]*,"profile_path":null,"order":([0-9]*)</expression>
 			</RegExp>
+			<RegExp input="$$1" output="\1" dest="1">
+				<expression clear="yes">({"air_date":"[^"]*","episode_number":$$11,"id":\d+,.+)</expression>
+			</RegExp>
 			<RegExp input="$$1" output="\1" dest="7">
 				<expression clear="yes" noclean="1">"guest_stars":\[([^\]]+)\]</expression>
 			</RegExp>
-			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;thumb&gt;$$20original\3&lt;/thumb&gt;&lt;/actor&gt;" dest="5+">
-				<expression repeat="yes" fixchars="1,2">"name":"([^"]*)","credit_id":"[^"]*","character":"((?:[^"]|(?&lt;=\\)")*)","profile_path":"([^"]*)","order":[0-9]*</expression>
+			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;thumb&gt;$$20original\4&lt;/thumb&gt;&lt;/actor&gt;" dest="5+">
+				<expression repeat="yes" fixchars="1,2">"name":"([^"]*)","credit_id":"[^"]*","character":"((?:[^"]|(?&lt;=\\)")*)","order":([0-9]*),"gender":[0-9]*,"profile_path":"([^"]*)"</expression>
 			</RegExp>
-			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;/actor&gt;" dest="5+">
-				<expression repeat="yes" fixchars="1,2">"name":"([^"]*)","credit_id":"[^"]*","character":"((?:[^"]|(?&lt;=\\)")*)","profile_path":null,"order":[0-9]*</expression>
+			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;/actor&gt;" dest="5+">
+				<expression repeat="yes" fixchars="1,2">"name":"([^"]*)","credit_id":"[^"]*","character":"((?:[^"]|(?&lt;=\\)")*)","order":([0-9]*),"gender":[0-9]*,"profile_path":null</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -374,24 +474,24 @@
 			<expression noclean="1" />
 		</RegExp>	
 	</ParseSeasonArt>
-	<GetEpisodeArt dest="3">
+	<GetEpisodeArt dest="3" clearbuffers="no">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
 				<expression>^([0-9]+)\|</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-episode-s\2e\3.json&quot; function=&quot;ParseEpisodeArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2/episode/\3/images?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
-				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression>
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseEpisodeArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+				<RegExp input="$$1" output="\1" dest="11">
+					<expression>^[0-9]+\|[0-9]+\|([0-9]+)$</expression>
+				</RegExp>
+				<expression>^([0-9]+)\|([0-9]+)\|[0-9]+$</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</GetEpisodeArt>
 	<ParseEpisodeArt dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$7" output="&lt;thumb&gt;$$20original\1&lt;/thumb&gt;" dest="5">
-				<RegExp input="$$1" output="\1" dest="7">
-					<expression clear="yes">"stills":\[([^\]]*)\]</expression>
-				</RegExp>
-				<expression repeat="yes">"file_path":"([^"]*)"</expression>
+			<RegExp input="$$1" output="&lt;thumb&gt;$$20original\1&lt;/thumb&gt;" dest="5">
+				<expression clear="yes">"episode_number":$$11,[^[]+,"still_path":"([^"]*)"</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>	


### PR DESCRIPTION
### Description
This update includes the changes as discussed in the forums to reduce the number of API calls.
It also includes a 15 minute cache persistence, which may or may not help, but can't hurt.

It also, more significantly, includes Episode Group and Named Season support.

The Episode Group support works via nfo files.  The user needs to include the Episode Group URL in the tvshow.nfo, and the scraper will then save the Episode Group id along with the show id and use it when building the episode list.  
There are a few caveats to this, the Groups are always numbered in order, starting at 1, regardless of how they are _named_ on the site.  This can differ from thetvdb where the first season might be _numbered_ "2010" and you would have to number the files s2010e01, etc.  With the Episode Groups, "2010" would only be the _name_ of the season.  You would still number the files s01e01, etc.  This is why I've also included Named Season support, the season will still appear as "2010" in Kodi.

Special (Season 0) episodes are treated separately and always added, as Episode Groups don't list them, unless they appear individually in a Group.

Also, for some unknown reason, the two order fields in the Episode Group API act differently.  The Group order is 1-indexed (i.e. starts at Season 1), but the Episode order is 0-indexed (i.e starts at Episode 0).  
It might just be an oversight on themoviedb's part, or there could be some deeper meaning to it, but it means I have to +1 that order for it to make sense.  Which means using XSLT briefly.  Which, after openelec, always concerns me somewhat.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
