### PR TITLE
[metadata.universal] v5.3.4

### DIFF
--- a/metadata.universal/addon.xml
+++ b/metadata.universal/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.universal"
        name="Universal Movie Scraper"
-       version="5.3.3"
+       version="5.3.4"
        provider-name="Olympia, Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.universal/changelog.txt
+++ b/metadata.universal/changelog.txt
@@ -1,3 +1,6 @@
+[B]5.3.4[/B]
+- fixed: search results
+
 [B]5.3.2[/B]
 - fixed: search results
 

--- a/metadata.universal/universal.xml
+++ b/metadata.universal/universal.xml
@@ -49,10 +49,10 @@
 	<GetSearchResults dest="8">
 		<RegExp input="$INFO[searchservice]" output="$$17" dest="8">
 			<RegExp input="$$5" output="&lt;results&gt;\1&lt;/results&gt;" dest="17">
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\4&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="3">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\4&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5">
 					<expression repeat="yes">&quot;id&quot;:([0-9]*).*?original_title&quot;:&quot;([^&quot;]*)&quot;.*?&quot;release_date&quot;:&quot;(([0-9]+)-)?</expression>
 				</RegExp>
-				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\4&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\4&lt;/year&gt;&lt;url cache=&quot;tmdb-$INFO[tmdbsearchlanguage]-\1.json&quot;&gt;https://api.tmdb.org/3/movie/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[tmdbsearchlanguage]&lt;/url&gt;&lt;/entity&gt;" dest="5+">
 					<expression repeat="yes">&quot;id&quot;:([0-9]*).*?&quot;title&quot;:&quot;([^&quot;]*)&quot;.*?&quot;release_date&quot;:&quot;(([0-9]+)-)?</expression>
 				</RegExp>
 				<expression noclean="1" />


### PR DESCRIPTION
### Description
Fixed TMDB search failure.

With v5.3.3, I was getting `scraper: GetSearchResults returned <results></results>`.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
