### PR TITLE
[metadata.tvmaze] 1.0.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
-  name="TV Maze"
-  version="1.0.0"
+  name="TVmaze"
+  version="1.0.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -11,8 +11,9 @@
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en_GB">TV show scraper for tvmaze.com</summary>
-    <description lang="en_GB">TV show scraper for tvmaze.com.</description>
+    <summary lang="en_GB">Fetch TV Show metadata from TVmaze.com</summary>
+    <description lang="en_GB">TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
+We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.</description>
     <platform>all</platform>
     <license>GPL v3.0</license>
     <assets>
@@ -22,6 +23,8 @@
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
     <news>1.0.0:
-- Initial release.</news>
+- Fixed a bug with empty ratings.
+- Added a workaround for a Kodi bug when episoude guide URL from NFO is passed to a scraper.
+- Artwork is now sorted by main property.</news>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -23,7 +23,7 @@ from six import itervalues
 from six.moves import urllib_parse
 import xbmcgui
 import xbmcplugin
-from . import tvmaze, data_utils, cache
+from . import tvmaze, data_utils
 from .utils import logger
 
 HANDLE = int(sys.argv[1])
@@ -41,11 +41,7 @@ def find_show(title, year=None):
         if search_result['show']['premiered']:
             show_name += u' ({})'.format(search_result['show']['premiered'][:4])
         list_item = xbmcgui.ListItem(show_name, offscreen=True)
-        image = search_result['show']['image']
-        if image is not None:
-            thumb = image['medium']
-            # In scrapers this method must be used to set list item images.
-            list_item.addAvailableArtwork(thumb, 'thumb')
+        list_item = data_utils.add_main_show_info(list_item, search_result['show'], False)
         # Below "url" is some unique ID string (may be an actual URL to a show page)
         # that is used to get information about a specific TV show.
         xbmcplugin.addDirectoryItem(
@@ -65,18 +61,22 @@ def get_show_from_nfo(nfo):
 
     :param nfo: the contents of a NFO file
     """
-    logger.debug('Parsing NFO file:\n{}'.format(nfo))
+    if isinstance(nfo, bytes):
+        nfo = nfo.decode('utf-8', 'replace')
+    logger.debug(u'Parsing NFO file:\n{}'.format(nfo))
     parse_result = data_utils.parse_nfo_url(nfo)
     if parse_result:
         if parse_result.provider == 'tvmaze':
             show_info = tvmaze.load_show_info(parse_result.show_id)
         else:
-            show_info = tvmaze.load_show_info_by_external_id(
+            brief_show_info = tvmaze.load_show_info_by_external_id(
                 parse_result.provider,
                 parse_result.show_id
             )
+            show_info = tvmaze.load_show_info(brief_show_info['id'])
         if show_info is not None:
             list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
+            list_item = data_utils.add_main_show_info(list_item, show_info, False)
             xbmcplugin.addDirectoryItem(
                 HANDLE,
                 url=str(show_info['id']),
@@ -94,12 +94,28 @@ def get_details(show_id):
         list_item = data_utils.add_main_show_info(list_item, show_info)
         xbmcplugin.setResolvedUrl(HANDLE, True, list_item)
     else:
-        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
+        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
 def get_episode_list(show_id):
     logger.debug('Getting episode list for show id {}'.format(show_id))
-    show_info = tvmaze.load_show_info(show_id)
+    if not show_id.isdigit():
+        # Kodi has a bug: when a show directory contains an XML NFO file with
+        # episodeguide URL, that URL is always passed here regardless of
+        # the actual parsing result in get_show_from_nfo()
+        parse_result = data_utils.parse_nfo_url(show_id)
+        if not parse_result:
+            return
+        if parse_result.provider == 'tvmaze':
+            show_info = tvmaze.load_show_info(parse_result.show_id)
+        else:
+            brief_show_info = tvmaze.load_show_info_by_external_id(
+                parse_result.provider,
+                parse_result.show_id
+            )
+            show_info = tvmaze.load_show_info(brief_show_info['id'])
+    else:
+        show_info = tvmaze.load_show_info(show_id)
     if show_info is not None:
         for episode in itervalues(show_info['episodes']):
             list_item = xbmcgui.ListItem(episode['name'], offscreen=True)
@@ -130,7 +146,7 @@ def get_episode_details(encoded_ids):
         list_item = data_utils.add_episode_info(list_item, episode_info, full_info=True)
         xbmcplugin.setResolvedUrl(HANDLE, True, list_item)
     else:
-        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
+        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
 def get_artwork(show_id):
@@ -142,11 +158,11 @@ def get_artwork(show_id):
     logger.debug('Getting artwork for show ID {}'.format(show_id))
     show_info = tvmaze.load_show_info(show_id)
     if show_info is not None:
-        list_item = xbmcgui.ListItem(show_info['name'])
+        list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
         list_item = data_utils.set_show_artwork(show_info, list_item)
         xbmcplugin.setResolvedUrl(HANDLE, True, list_item)
     else:
-        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
+        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
 def router(paramstring):

--- a/metadata.tvmaze/libs/cache.py
+++ b/metadata.tvmaze/libs/cache.py
@@ -17,6 +17,7 @@
 
 """Cache-related functionality"""
 
+from __future__ import absolute_import
 import os
 from datetime import datetime, timedelta
 from six.moves import cPickle as pickle
@@ -43,7 +44,7 @@ def load_show_info_from_cache(show_id):
     """
     Load show info from a local cache
 
-    :param show_id: show ID on TV Maze
+    :param show_id: show ID on TVmaze
     :return: show_info dict or None
     """
     file_name = str(show_id) + '.pickle'

--- a/metadata.tvmaze/libs/data_utils.py
+++ b/metadata.tvmaze/libs/data_utils.py
@@ -17,6 +17,7 @@
 
 """Functions to process data"""
 
+from __future__ import absolute_import
 import re
 from collections import OrderedDict, namedtuple
 import six
@@ -25,7 +26,7 @@ from .utils import safe_get
 TAG_RE = re.compile(r'<[^>]+>')
 SHOW_ID_REGEXPS = (
     r'(tvmaze)\.com/shows/(\d+)/[\w\-]',
-    r'(thetvdb)\.com/series/(\d+)',
+    r'(thetvdb)\.com/.*?series/(\d+)',
     r'(thetvdb)\.com[\w=&\?/]+id=(\d+)',
     r'(imdb)\.com/[\w/\-]+/(tt\d+)',
 )
@@ -104,7 +105,7 @@ def _set_unique_ids(show_info, list_item):
 
 def _set_rating(show_info, list_item):
     """Set show rating"""
-    if show_info['rating'] is not None:
+    if show_info['rating'] is not None and show_info['rating']['average'] is not None:
         rating = float(show_info['rating']['average'])
         list_item.setRating('tvmaze', rating, defaultt=True)
     return list_item
@@ -149,7 +150,7 @@ def set_show_artwork(show_info, list_item):
     return list_item
 
 
-def add_main_show_info(list_item, show_info):
+def add_main_show_info(list_item, show_info, full_info=True):
     """Add main show info to a list item"""
     plot = _clean_plot(safe_get(show_info, 'summary', ''))
     video = {
@@ -159,24 +160,38 @@ def add_main_show_info(list_item, show_info):
         'title': show_info['name'],
         'tvshowtitle': show_info['name'],
         'status': safe_get(show_info, 'status', ''),
-        'credits': _get_credits(show_info),
         'mediatype': 'tvshow',
         # This property is passed as "url" parameter to getepisodelist call
         'episodeguide': str(show_info['id']),
     }
     if show_info['network'] is not None:
-        video['studio'] = show_info['network']['name']
-        video['country'] = show_info['network']['country']['name']
+        country = show_info['network']['country']
+        video['studio'] = u'{0} ({1})'.format(show_info['network']['name'], country['code'])
+        video['country'] = country['name']
+    elif show_info['webChannel'] is not None:
+        video['studio'] = show_info['webChannel']['name']
+        # Global Web Channels do not have a country specified
+        if show_info['webChannel']['country'] is not None:
+            country = show_info['webChannel']['country']
+            video['country'] = country['name']
+            video['studio'] += u' ({})'.format(country['code'])
     if show_info['premiered'] is not None:
         video['year'] = int(show_info['premiered'][:4])
         video['premiered'] = show_info['premiered']
+    if full_info:
+        video['credits'] = _get_credits(show_info)
+        list_item = set_show_artwork(show_info, list_item)
+        list_item = _add_season_info(show_info, list_item)
+        list_item = _set_cast(show_info, list_item)
+    else:
+        image = safe_get(show_info, 'image', {})
+        image_url = _extract_artwork_url(image)
+        if image_url:
+            list_item.addAvailableArtwork(image_url, 'poster')
     list_item.setInfo('video', video)
-    list_item = set_show_artwork(show_info, list_item)
-    list_item = _add_season_info(show_info, list_item)
+    list_item = _set_rating(show_info, list_item)
     # This is needed for getting artwork
     list_item = _set_unique_ids(show_info, list_item)
-    list_item = _set_cast(show_info, list_item)
-    list_item = _set_rating(show_info, list_item)
     return list_item
 
 
@@ -199,8 +214,11 @@ def add_episode_info(list_item, episode_info, full_info=True):
         if episode_info['airdate'] is not None:
             video['premiered'] = episode_info['airdate']
     list_item.setInfo('video', video)
-    if episode_info['image']:
-        list_item.addAvailableArtwork(episode_info['image']['original'], 'thumb')
+    image = safe_get(episode_info, 'image', {})
+    image_url = _extract_artwork_url(image)
+    if image_url:
+        list_item.addAvailableArtwork(image_url, 'thumb')
+    list_item.setUniqueIDs({'tvmaze': str(episode_info['id'])}, 'tvmaze')
     return list_item
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.0.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.0.0:
- Fixed a bug with empty ratings.
- Added a workaround for a Kodi bug when episoude guide URL from NFO is passed to a scraper.
- Artwork is now sorted by main property.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
