### PR TITLE
[metadata.tvshows.themoviedb.org] updated to v3.5.0

### DIFF
--- a/metadata.tvshows.themoviedb.org/addon.xml
+++ b/metadata.tvshows.themoviedb.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.themoviedb.org"
        name="The Movie Database"
-       version="3.4.2"
+       version="3.5.0"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.tvshows.themoviedb.org/changelog.txt
+++ b/metadata.tvshows.themoviedb.org/changelog.txt
@@ -1,3 +1,12 @@
+[B]3.5.0[/B]
+- Added: Year to search query
+- Added: Return results based on the "name" field as well as "original_name"
+- Added: Multiple episode thumbs
+- Changed: Artwork order, so tmdb artwork is first
+- Changed: Reduce the number of files requested from tmdb
+- Changed: Update URLs to https
+- Fixed: Fetch all series regular actors not just current season
+
 [B]3.4.2[/B]
 - Fixed: Unscraped episodes caused by Square brackets in plot (thanks scudlee)
 

--- a/metadata.tvshows.themoviedb.org/tmdb.xml
+++ b/metadata.tvshows.themoviedb.org/tmdb.xml
@@ -1,26 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2013-10-26">
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://api.themoviedb.org/3/search/tv?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;query=\1&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-search-\1$$6-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/search/tv?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;query=\1$$5&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="3">
+			<RegExp input="$$2" output="&amp;amp;first_air_date_year=\1" dest="5">
+				<expression clear="yes">(.+)</expression>
+			</RegExp>
+ 			<RegExp input="$$2" output="-(\1)" dest="6">
+				<expression clear="yes">(.+)</expression>
+			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</CreateSearchUrl>
 
 	<NfoUrl dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
 				<expression clear="yes" noclean="1">imdb....?/title/(tt[0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/tt\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/tt\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=imdb_id&lt;/url&gt;" dest="5">
 				<expression noclean="1">imdb....?/Title\?([0-9]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;http://api.themoviedb.org/3/find/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=tvdb_id&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;GetTMDBId&quot;&gt;https://api.themoviedb.org/3/find/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;external_source=tvdb_id&lt;/url&gt;" dest="5">
 				<expression noclean="1">https?://(?:www\.)?thetvdb\.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
 				<expression noclean="1">themoviedb\.org/tv/([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1|\2&lt;/id&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1|\2&lt;/id&gt;" dest="5">
 				<expression noclean="1">themoviedb\.org/tv/([0-9]+)[^\/]*/episode_group/([0-9a-f]+)</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -28,7 +34,7 @@
 	</NfoUrl>
 	<GetTMDBId dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$7" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
+			<RegExp input="$$7" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="5">
 				<RegExp input="$$1" output="\1" dest="7">
 					<expression noclean="1">"tv_results":\[([^\]]+)\]</expression>
 				</RegExp>
@@ -40,28 +46,22 @@
 
 	<GetSearchResults dest="8">
 		<RegExp input="$$3" output="&lt;results&gt;\1&lt;/results&gt;" dest="8">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3">
-				<expression repeat="yes">&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:&quot;([0-9]+).*?&quot;original_name&quot;:&quot;([^&quot;]*)&quot;</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-\2-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3">
+				<expression repeat="yes">"original_name":"([^"]*)"[^}]*,"id":([0-9]*),[^}]*"first_air_date":"(?:|([0-9]+)[^"]*?)"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\1&lt;/id&gt;&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
-				<expression repeat="yes">&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:null.*?&quot;original_name&quot;:&quot;([^&quot;]*)&quot;</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\3&lt;/id&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;tmdb-\3-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\3?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+				<expression repeat="yes">"original_name":"([^"]*)"[^}]*,"first_air_date":"(?:|([0-9]+)[^"]*?)"[^}]*,"id":([0-9]*),</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-\2-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
-				<expression repeat="yes">original_name&quot;:&quot;([^&quot;]*)&quot;,&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:&quot;([0-9]+).*?&quot;</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;year&gt;\4&lt;/year&gt;&lt;url cache=&quot;tmdb-\2-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+				<expression repeat="yes">"original_name":"([^"]*)"[^}]*,"id":([0-9]*),[^}]*"name":"(?!\1")([^"]*)"[^}]*,"first_air_date":"(?:|([0-9]+)[^"]*?)"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;url cache=&quot;tmdb-\2-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
-				<expression repeat="yes">original_name&quot;:&quot;([^&quot;]*)&quot;,&quot;id&quot;:([0-9]*),.*?&quot;first_air_date&quot;:null.*?&quot;</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\3&lt;/id&gt;&lt;year&gt;\2&lt;/year&gt;&lt;url cache=&quot;tmdb-\3-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\3?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
-				<expression repeat="yes">original_name&quot;:&quot;([^&quot;]*)&quot;,.*?first_air_date&quot;:&quot;([0-9]+).*?&quot;id&quot;:([0-9]*)</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;id&gt;\2&lt;/id&gt;&lt;url cache=&quot;tmdb-\2-$INFO[language].json&quot;&gt;http://api.themoviedb.org/3/tv/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
-				<expression repeat="yes">original_name&quot;:&quot;([^&quot;]*)&quot;,.*?first_air_date&quot;:null.*?&quot;.*?&quot;id&quot;:([0-9]*)</expression>
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;id&gt;\4&lt;/id&gt;&lt;year&gt;\3&lt;/year&gt;&lt;url cache=&quot;tmdb-\4-$INFO[language].json&quot;&gt;https://api.themoviedb.org/3/tv/\4?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;/entity&gt;" dest="3+">
+				<expression repeat="yes">"original_name":"([^"]*)"[^}]*,"name":"(?!\1")([^"]*)"[^}]*,"first_air_date":"(?:|([0-9]+)[^"]*?)"[^}]*,"id":([0-9]*),</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</GetSearchResults>
-	
+
 	<GetDetails dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
 			<RegExp input="$$2" output="\1" dest="10">
@@ -82,8 +82,17 @@
 			<RegExp input="$$10" output="&lt;id&gt;\1&lt;/id&gt;&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
 				<expression/>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetTVShowExtIDs&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
-				<expression />
+			<RegExp input="$$1" output="\1" dest="14">
+				<expression>"imdb_id":"(tt\d+)"</expression>
+			</RegExp>
+			<RegExp input="$$1" output="\1" dest="19">
+				<expression>"tvdb_id":(\d+),</expression>
+			</RegExp>
+			<RegExp input="$$14" output="&lt;uniqueid type=&quot;imdb&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+				<expression>(.+)</expression>
+			</RegExp>
+			<RegExp input="$$19" output="&lt;uniqueid type=&quot;tvdb&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;year&gt;\1&lt;/year&gt;" dest="5+">
 				<expression noclean="1">"first_air_date":"([0-9]+)-</expression>
@@ -108,10 +117,10 @@
 			</RegExp>
 			<RegExp input="$$8" output="\1" dest="5+">
 				<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="7">
-					<expression>&quot;type&quot;.+?&quot;vote_average&quot;:([^,]*),</expression>
+					<expression>"type".+?"vote_average":([^,]*),</expression>
 				</RegExp>
 				<RegExp input="$$1" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="7+">
-					<expression>&quot;type&quot;.+?&quot;vote_count&quot;:([0-9]+)</expression>
+					<expression>"type".+?"vote_count":([0-9]+)</expression>
 				</RegExp>
 				<RegExp input="$INFO[RatingS]" output="default=&quot;true&quot;" dest="17">
 					<expression>Themoviedb</expression>
@@ -119,16 +128,16 @@
 				<RegExp input="$INFO[RatingS]|$INFO[fallback]" output="&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot; $$17&gt;$$7&lt;/rating&gt;&lt;/ratings&gt;" dest="8">
 					<expression>Themoviedb|true</expression>
 				</RegExp>
-				<RegExp input="$INFO[RatingS]|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetIMDbTVShowRating&quot;&gt;$$10&lt;/chain&gt;" dest="8+">
-					<expression>IMDb|true</expression>
-				</RegExp>
 				<expression noclean="1">(.+)</expression>
 			</RegExp>
-			<RegExp input="$$10" output="&lt;url function=&quot;ParseTVShowContentRating&quot;&gt;https://api.themoviedb.org/3/tv/$$10/content_ratings?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en-US&lt;/url&gt;" dest="5+">
-				<expression />
+			<RegExp input="$$14|$INFO[RatingS]|default|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetIMDBRatingsById&quot;&gt;$$14\1&lt;/chain&gt;" dest="5+">
+				<expression>^tt\d+\|(?:IMDb(\|default)|.*true$)</expression>
 			</RegExp>
-			<RegExp input="$$10" output="&lt;chain function=&quot;GetCast&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
-				<expression />
+			<RegExp input="$$1" output="&lt;mpaa&gt;$INFO[certprefix]\1&lt;/mpaa&gt;" dest="5+">
+				<expression>"$INFO[tmdbcertcountry]","rating":"([^"]*)"</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;chain function=&quot;GetCast&quot;&gt;$$10|\1&lt;/chain&gt;" dest="5+">
+				<expression repeat="yes">"season_number":([0-9]+)</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;genre&gt;\1&lt;/genre&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="7">
@@ -137,27 +146,18 @@
 				<expression repeat="yes" fixchars="1">"name":"([^"]*)</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="9">
-				<expression clear="yes" fixchars="1">original_name&quot;:&quot;[^&quot;]*&quot;,&quot;overview&quot;:&quot;(.+?)&quot;,&quot;popularity&quot;</expression>
+				<expression clear="yes" fixchars="1">original_name":"[^"]*","overview":"(.+?)","popularity"</expression>
 			</RegExp>
 			<RegExp input="$$9" output="&lt;plot&gt;\1&lt;/plot&gt;" dest="5+">
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$10-en.json&quot;&gt;http://api.themoviedb.org/3/tv/$$10?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$10-en.json&quot;&gt;https://api.themoviedb.org/3/tv/$$10?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
 			</RegExp>
-			<RegExp input="$$1" output="\1" dest="19">
-				<expression>&quot;tvdb_id&quot;:([^,]*),</expression>
-			</RegExp>
-			<RegExp input="$$19" output="&lt;uniqueid type=&quot;tvdb&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
-				<expression/>
-			</RegExp>
-			<RegExp conditional="fanarttvart" input="$$19" output="&lt;chain function=&quot;GetFanartTvArt&quot;&gt;\1&lt;/chain&gt;" dest="5+">
-				<expression />
-			</RegExp>
-			<RegExp conditional="tmdbart" input="$$10" output="&lt;chain function=&quot;GetArt&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
+			<RegExp input="$$10" output="&lt;chain function=&quot;GetArt&quot;&gt;$$10&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<RegExp input="$$1" output="&lt;namedseason number=&quot;\2&quot;&gt;\1&lt;/namedseason&gt;" dest="5+">
@@ -167,16 +167,16 @@
 				<RegExp input="$$1" output="&lt;namedseason number=&quot;\2&quot;&gt;\1&lt;/namedseason&gt;" dest="8">
 					<expression repeat="yes" fixchars="1">"name":"([^}]+)","overview":[^}]*?"season_number":(?!0})([0-9]+)}</expression>
 				</RegExp>
-				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupSeasonNames&quot; cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="8">
+				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupSeasonNames&quot; cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;https://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="8">
 					<expression>\|([0-9a-f]+)$</expression>
 				</RegExp>
 				<expression noclean="1"/>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;url cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="12">
+			<RegExp input="$$2" output="&lt;url cache=&quot;tmdb-$$10-$INFO[language]-episode_group-\1.json&quot;&gt;https://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="12">
 				<expression clear="yes">\|([0-9a-f]+)$</expression>
 			</RegExp>
 			<RegExp input="$$3" output="&lt;episodeguide&gt;&lt;url cache=&quot;tmdb-$$10-$INFO[language].json&quot;&gt;\1&lt;/url&gt;$$12&lt;/episodeguide&gt;" dest="5+">
-				<expression>(.*)&amp;append</expression>
+				<expression/>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -188,22 +188,22 @@
 				<expression repeat="yes" fixchars="1">"name":"([^[\]]*?)","order":([0-9]+),"episodes"</expression>
 			</RegExp>
 			<expression noclean="1"/>
-		</RegExp>	
+		</RegExp>
 	</GetEpisodeGroupSeasonNames>
-	
+
 	<GetEpisodeList clearbuffers="no" dest="3">
 		<RegExp input="$$4" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="3">
 			<RegExp input="$$1" output="\1" dest="5">
 				<expression>"id":([0-9]+),"in_production"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;https://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="4">
 				<expression clear="yes">"season_number":(0)}</expression>
 			</RegExp>
 			<RegExp input="$$9" output="\1" dest="4+">
-				<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="9">
-					<expression repeat="yes">"season_number":(?!0})([0-9]+)</expression>
+				<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-\1.json&quot; function=&quot;GetSeasonEpisodeList&quot;&gt;https://api.themoviedb.org/3/tv/$$5/season/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="9">
+					<expression repeat="yes">"season_number":(?!0})([0-9]+)}</expression>
 				</RegExp>
-				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupList&quot; cache=&quot;tmdb-$$5-$INFO[language]-episode_group-\1.json&quot;&gt;http://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="9">
+				<RegExp input="$$2" output="&lt;url function=&quot;GetEpisodeGroupList&quot; cache=&quot;tmdb-$$5-$INFO[language]-episode_group-\1.json&quot;&gt;https://api.themoviedb.org/3/tv/episode_group/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="9">
 					<expression>"id":"([0-9a-f]+)","name":"[^}]*","network"</expression>
 				</RegExp>
 				<expression noclean="1"/>
@@ -216,7 +216,7 @@
 			<RegExp input="$$1" output="\1" dest="6">
 				<expression clear="yes">"season_number":([0-9]+)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-$$6.json&quot;&gt;http://api.themoviedb.org/3/tv/$$5/season/$$6?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\3&lt;/id&gt;&lt;/episode&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\3&lt;/epnum&gt;&lt;season&gt;$$6&lt;/season&gt;&lt;url cache=&quot;tmdb-$$5-$INFO[language]-season-$$6.json&quot;&gt;https://api.themoviedb.org/3/tv/$$5/season/$$6?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;$$5|$$6|\3&lt;/id&gt;&lt;/episode&gt;" dest="4">
 				<expression repeat="yes" clear="yes">"air_date":("([^"]+)"|null),"episode_number":([0-9]+),"id":[0-9]+,"name":"((?:[^"]|(?&lt;=\\)")*)",</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -229,7 +229,7 @@
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="18">
 				<expression noclean="1"/>
-			</RegExp>		
+			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
 	</GetEpisodeGroupList>
@@ -237,19 +237,19 @@
 		<RegExp input="$$15" output="\1" dest="3">
 			<RegExp input="$$18" output="&lt;!-- Group name: \1 --&gt;" dest="4">
 				<expression>"name":"([^[\]{]+)","network":</expression>
-			</RegExp>	
+			</RegExp>
 			<RegExp input="$$18" output="&lt;!-- Season name: \1 --&gt;" dest="4+">
 				<expression>"name":"([^[\]{]+)","order":$$1</expression>
 			</RegExp>
 			<RegExp input="$$18" output="\1" dest="6">
 				<expression>"order":$$1,"episodes":(.*?)\](?:,"locked"|\})</expression>
-			</RegExp>	
-			<RegExp input="$$6" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\7&lt;/epnum&gt;&lt;season&gt;$$1&lt;/season&gt;&lt;url cache=&quot;tmdb-\6-$INFO[language]-season-\5.json&quot;&gt;http://api.themoviedb.org/3/tv/\6/season/\5?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\6|\5|\3&lt;/id&gt;&lt;/episode&gt;" dest="4+">
+			</RegExp>
+			<RegExp input="$$6" output="&lt;episode&gt;&lt;title&gt;\4&lt;/title&gt;&lt;aired&gt;\2&lt;/aired&gt;&lt;epnum&gt;\7&lt;/epnum&gt;&lt;season&gt;$$1&lt;/season&gt;&lt;url cache=&quot;tmdb-\6-$INFO[language]-season-\5.json&quot;&gt;https://api.themoviedb.org/3/tv/\6/season/\5?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;&lt;id&gt;\6|\5|\3&lt;/id&gt;&lt;/episode&gt;" dest="4+">
 				<expression repeat="yes">{"air_date":("([^"]+)"|null),"episode_number":([0-9]+),"id":[0-9]+,"name":"((?:[^"]|(?&lt;=\\)")*)",[^}]+"season_number":([0-9]+),"show_id":([0-9]+),[^}]+"order":([0-9]+)</expression>
-			</RegExp>	
+			</RegExp>
 			<RegExp input="" output="" dest="15">
 				<expression/>
-			</RegExp>	
+			</RegExp>
 			<XSLT input="&lt;episodeguide&gt;$$4&lt;/episodeguide&gt;" output="\1" dest="15">
 				<xsl:stylesheet version = "1.0"
 					xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -265,7 +265,7 @@
 					</xsl:template>
 					<xsl:template match="id">
 						<id><xsl:value-of select="."/>|<xsl:value-of select="../season"/>|<xsl:value-of select="../epnum+1"/></id>
-					</xsl:template>								
+					</xsl:template>
 				</xsl:stylesheet>
 			</XSLT>
 			<expression noclean="1"/>
@@ -296,7 +296,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBEpisodeTitle&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;http://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBEpisodeTitle&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;https://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -310,15 +310,12 @@
 			<RegExp input="$$1" output="&lt;uniqueid type=&quot;tmdb&quot; default=&quot;true&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
 				<expression>"id":([0-9]+),"name"</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;chain function=&quot;GetEpExtIDs&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="5+">
-				<expression />
-			</RegExp>
 			<RegExp input="$$8" output="\1" dest="5+">
 				<RegExp input="$$1" output="&lt;value&gt;\1&lt;/value&gt;" dest="7">
-					<expression>&quot;vote_average&quot;:([^&quot;]*)</expression>
+					<expression>"vote_average":([^,]*),</expression>
 				</RegExp>
 				<RegExp input="$$1" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="7+">
-					<expression>&quot;vote_count&quot;:([0-9]+)</expression>
+					<expression>"vote_count":([0-9]+)</expression>
 				</RegExp>
 				<RegExp input="$INFO[RatingS]" output="default=&quot;true&quot;" dest="16">
 					<expression>Themoviedb</expression>
@@ -326,10 +323,10 @@
 				<RegExp input="$INFO[RatingS]|$INFO[fallback]" output="&lt;ratings&gt;&lt;rating name=&quot;themoviedb&quot; $$16&gt;$$7&lt;/rating&gt;&lt;/ratings&gt;" dest="8">
 					<expression>Themoviedb|true</expression>
 				</RegExp>
-				<RegExp input="$INFO[RatingS]|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetIMDbEpRating&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="8+">
-					<expression>IMDb|true</expression>
-				</RegExp>
 				<expression noclean="1">(.+)</expression>
+			</RegExp>
+			<RegExp input="$INFO[RatingS]|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetEpisodeExtraDetails&quot;&gt;$$6|$$10|$$11|ParseEpisodeIMDBRatingsById&lt;/chain&gt;" dest="5+">
+				<expression>IMDb|true</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="9">
 				<expression clear="yes" fixchars="1">"overview":"([^\{]*?)","production_code"</expression>
@@ -338,7 +335,7 @@
 				<expression>(.+)</expression>
 			</RegExp>
 			<RegExp input="$$9" output="$$8" dest="5+">
-				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;http://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
+				<RegExp input="$INFO[language]" output="&lt;url function=&quot;ParseFallbackTMDBPlot&quot; cache=&quot;tmdb-$$6-en-episode-s$$10e$$11.json&quot;&gt;https://api.themoviedb.org/3/tv/$$6/season/$$10/episode/$$11?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en&lt;/url&gt;" dest="8">
 					<expression clear="yes">^(?!en).*</expression>
 				</RegExp>
 				<expression>^$</expression>
@@ -355,93 +352,15 @@
 			<RegExp input="" output="&lt;chain function=&quot;GetCast&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
-			<RegExp input="" output="&lt;chain function=&quot;GetEpisodeArt&quot;&gt;$$6|$$10|$$11&lt;/chain&gt;" dest="5+">
+			<RegExp input="" output="&lt;chain function=&quot;GetEpisodeExtraDetails&quot;&gt;$$6|$$10|$$11|ParseEpisodeExternalIds&lt;/chain&gt;" dest="5+">
+				<expression />
+			</RegExp>
+			<RegExp input="" output="&lt;chain function=&quot;GetEpisodeExtraDetails&quot;&gt;$$6|$$10|$$11|ParseEpisodeArt&lt;/chain&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1"/>
 		</RegExp>
 	</GetEpisodeDetails>
-
-	<GetEpExtIDs dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseEpExtIDs&quot; cache=&quot;tmdbids-\1\2\3&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2/episode/\3/external_ids?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
-				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetEpExtIDs>
-
-	<ParseEpExtIDs dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;uniqueid type=&quot;tvdb&quot;&gt;\1&lt;/uniqueid&gt;" dest="5">
-				<expression>"tvdb_id":([0-9]+),</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;uniqueid type=&quot;imdb&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
-				<expression>imdb_id":"([^"]*)</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseEpExtIDs>
-
-	<GetTVShowExtIDs dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTVShowExtIDs&quot; cache=&quot;tmdbids-\1&quot;&gt;https://api.themoviedb.org/3/tv/\1/external_ids?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en-US&lt;/url&gt;" dest="5">
-				<expression>^([0-9]+)$</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetTVShowExtIDs>
-
-	<ParseTVShowExtIDs dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;uniqueid type=&quot;tvdb&quot;&gt;\1&lt;/uniqueid&gt;" dest="5">
-				<expression>"tvdb_id":([0-9]+),</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;uniqueid type=&quot;imdb&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
-				<expression>imdb_id":"([^"]*)</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseTVShowExtIDs>
-
-	<GetIMDbEpRating dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetIMDbRatingByID&quot; cache=&quot;tmdbids-\1\2\3&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2/episode/\3/external_ids?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
-				<expression>^([0-9]+)\|([0-9]+)\|([0-9]+)$</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetIMDbEpRating>
-
-	<GetIMDbTVShowRating dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;url function=&quot;GetIMDbRatingByID&quot;&gt;https://api.themoviedb.org/3/tv/\1/external_ids?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=en-US&lt;/url&gt;" dest="5">
-				<expression>^([0-9]+)$</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetIMDbTVShowRating>
-
-	<GetIMDbRatingByID dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="\1" dest="14">
-				<expression>imdb_id":"([^"]*)</expression>
-			</RegExp>
-			<RegExp input="$$14|$INFO[RatingS]|default|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetIMDBRatingsById&quot;&gt;$$14\1&lt;/chain&gt;" dest="5">
-				<expression>^tt\d+\|(?:IMDb(\|default)|.*true$)</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</GetIMDbRatingByID>
-
-	<ParseTVShowContentRating dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;mpaa&gt;$INFO[certprefix]\1&lt;/mpaa&gt;" dest="5+">
-				<expression>&quot;$INFO[tmdbcertcountry]&quot;,&quot;rating&quot;:"([^"]*)"</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>
-	</ParseTVShowContentRating>	
 
 	<ParseFallbackTMDBPlot dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
@@ -472,13 +391,16 @@
 
 	<GetCast dest="3" clearbuffers="no">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits&lt;/url&gt;" dest="5+">
-				<expression>^([0-9]+)$</expression>
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseCast&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+				<RegExp input="-1" output="\1" dest="11">
+					<expression/>
+				</RegExp>
+				<expression>^([0-9]+)\|([0-9]+)$</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseCast&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseCast&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<RegExp input="$$1" output="\1" dest="11">
 					<expression>^[0-9]+\|[0-9]+\|([0-9]+)$</expression>
 				</RegExp>
@@ -492,11 +414,11 @@
 			<RegExp input="$$1" output="\1" dest="7">
 				<expression clear="yes" noclean="1">"cast":\[([^\]]+)\]</expression>
 			</RegExp>
-			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\4&lt;/order&gt;&lt;thumb&gt;$$20original\3&lt;/thumb&gt;&lt;/actor&gt;" dest="5">
-				<expression clear="yes" repeat="yes" fixchars="1,2">"character":"((?:[^"]|(?&lt;=\\)")*)","credit_id":"[^"]*","id":[0-9]*,"name":"([^"]*)","gender":[^,]*,"profile_path":"([^"]*)","order":([0-9]*)</expression>
+			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;thumb&gt;$$20original\4&lt;/thumb&gt;&lt;/actor&gt;" dest="5">
+				<expression clear="yes" repeat="yes" fixchars="1,2">"character":"((?:[^"]|(?&lt;=\\)")*)","credit_id":"[^"]*","gender":[^,]*,"id":[0-9]*,"name":"([^"]*)","order":([0-9]*),"profile_path":"([^"]*)"</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;/actor&gt;" dest="5+">
-				<expression repeat="yes" fixchars="1,2">"character":"((?:[^"]|(?&lt;=\\)")*)","credit_id":"[^"]*","id":[0-9]*,"name":"([^"]*)","gender":[^,]*,"profile_path":null,"order":([0-9]*)</expression>
+				<expression repeat="yes" fixchars="1,2">"character":"((?:[^"]|(?&lt;=\\)")*)","credit_id":"[^"]*","gender":[^,]*,"id":[0-9]*,"name":"([^"]*)","order":([0-9]*),"profile_path":null</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="1">
 				<expression clear="yes">({"air_date":"[^"]*","episode_number":$$11,"id":\d+,.+)</expression>
@@ -504,7 +426,7 @@
 			<RegExp input="$$1" output="\1" dest="7">
 				<expression clear="yes" noclean="1">"guest_stars":\[([^\]]+)\]</expression>
 			</RegExp>
-			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;thumb&gt;$$20original\4&lt;/thumb&gt;&lt;/actor&gt;" dest="5+">
+			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\1&lt;/name&gt;&lt;role&gt;\2&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;thumb&gt;$$20original\4&lt;/thumb&gt;&lt;/actor&gt;" dest="5">
 				<expression repeat="yes" fixchars="1,2">"name":"([^"]*)","credit_id":"[^"]*","character":"((?:[^"]|(?&lt;=\\)")*)","order":([0-9]*),"gender":[0-9]*,"profile_path":"([^"]*)"</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;actor&gt;&lt;name&gt;\2&lt;/name&gt;&lt;role&gt;\1&lt;/role&gt;&lt;order&gt;\3&lt;/order&gt;&lt;/actor&gt;" dest="5+">
@@ -514,12 +436,83 @@
 		</RegExp>
 	</ParseCast>
 
+	<GetEpisodeExtraDetails dest="3" clearbuffers="no">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseEpisodeExtrasList&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5">
+				<RegExp input="$$1" output="\1" dest="11">
+					<expression>^[0-9]+\|[0-9]+\|([0-9]+)\|[^|]+$</expression>
+				</RegExp>
+				<RegExp input="$$1" output="\1" dest="12">
+					<expression>^[0-9]+\|([0-9]+)\|[0-9]+\|[^|]+$</expression>
+				</RegExp>
+				<RegExp input="$$1" output="\1" dest="13">
+					<expression>^([0-9]+)\|[0-9]+\|[0-9]+\|[^|]+$</expression>
+				</RegExp>
+				<RegExp input="$$1" output="\1" dest="14">
+					<expression>^[0-9]+\|[0-9]+\|[0-9]+\|([^|]+)$</expression>
+				</RegExp>
+				<expression>^([0-9]+)\|([0-9]+)\|[0-9]+\|[^|]+$</expression>
+			</RegExp>
+			<expression noclean="1" />
+		</RegExp>
+	</GetEpisodeExtraDetails>
+	<ParseEpisodeExtrasList dest="4" clearbuffers="no">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
+			<RegExp input="$$11" output="\1" dest="6">
+				<expression clear="yes">^(\d*)\d$</expression>
+			</RegExp>
+			<RegExp input="$$1" output="episode/\1/images,episode/\1/external_ids," dest="7">
+				<expression repeat="yes" clear="yes">"episode_number":($$6\d),</expression>
+			</RegExp>
+			<RegExp input="$$14" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
+				<expression clear="yes">ParseEpisodeArt</expression>
+			</RegExp>
+			<RegExp input="$$7" output="&lt;url cache=&quot;tmdb-$$13-$INFO[language]-season-$$12-extra-$$6.json&quot; function=&quot;$$14&quot;&gt;https://api.themoviedb.org/3/tv/$$13/season/$$12?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=\1&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+				<expression>^(.+)$</expression>
+			</RegExp>
+			<expression noclean="1" />
+		</RegExp>
+	</ParseEpisodeExtrasList>
+
+	<ParseEpisodeExternalIds dest="4">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
+			<RegExp input="$$1" output="\1" dest="6">
+				<expression clear="yes">"episode/$$11/external_ids":{(.*?)}</expression>
+			</RegExp>
+			<RegExp input="$$6" output="&lt;uniqueid type=&quot;imdb&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5">
+				<expression clear="yes">"imdb_id":"(tt\d+)",</expression>
+			</RegExp>
+			<RegExp input="$$6" output="&lt;uniqueid type=&quot;tvdb&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+				<expression>"tvdb_id":(\d+),</expression>
+			</RegExp>
+			<RegExp input="$$6" output="&lt;uniqueid type=&quot;tvrage&quot; default=&quot;false&quot;&gt;\1&lt;/uniqueid&gt;" dest="5+">
+				<expression>"tvrage_id":(\d+)</expression>
+			</RegExp>
+			<expression noclean="1" />
+		</RegExp>
+	</ParseEpisodeExternalIds>
+
+	<ParseEpisodeIMDBRatingsById dest="4">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
+			<RegExp input="$$14|$INFO[RatingS]|default|$INFO[alsoimdb]" output="&lt;chain function=&quot;GetIMDBRatingsById&quot;&gt;$$14\1&lt;/chain&gt;" dest="5">
+				<RegExp input="$$6" output="\1" dest="14">
+					<RegExp input="$$1" output="\1" dest="6">
+						<expression clear="yes">"episode/$$11/external_ids":{(.*?)}</expression>
+					</RegExp>
+					<expression clear="yes">"imdb_id":"(tt\d+)",</expression>
+				</RegExp>
+				<expression clear="yes">^tt\d+\|(?:IMDb(\|default)|.*true$)</expression>
+			</RegExp>
+			<expression noclean="1" />
+		</RegExp>
+	</ParseEpisodeIMDBRatingsById>
+
 	<GetArt dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
 				<expression />
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseArt&quot;&gt;http://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language].json&quot; function=&quot;ParseArt&quot;&gt;https://api.themoviedb.org/3/tv/\1?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=content_ratings,credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
 			<expression noclean="1" />
@@ -527,7 +520,7 @@
 	</GetArt>
 	<ParseArt clearbuffers="no" dest="4">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="\1" dest="7">
+			<RegExp conditional="tmdbart" input="$$1" output="\1" dest="7">
 				<expression>"posters":\[([^\]]*)\]</expression>
 			</RegExp>
 			<RegExp input="$$7" output="&lt;thumb aspect=&quot;poster&quot;&gt;$$20original\1&lt;/thumb&gt;" dest="5">
@@ -536,7 +529,7 @@
 			<RegExp input="$$7" output="&lt;thumb aspect=&quot;poster&quot;&gt;$$20original\1&lt;/thumb&gt;" dest="5+">
 				<expression repeat="yes">"file_path":"([^"]*)","height":[0-9]+,"iso_639_1":(?!"$INFO[language]")</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;fanart url=&quot;$$20&quot; &gt;\1&lt;/fanart&gt;" dest="5+">
+			<RegExp conditional="tmdbart" input="$$8" output="&lt;fanart url=&quot;$$20&quot; &gt;\1&lt;/fanart&gt;" dest="5+">
 				<RegExp input="$$7" output="&lt;thumb dim=&quot;\3x\2&quot; preview=&quot;w780\1&quot;&gt;original\1&lt;/thumb&gt;" dest="8">
 					<RegExp input="$$1" output="\1" dest="7">
 						<expression>"backdrops":\[([^\]]*)\]</expression>
@@ -554,18 +547,21 @@
 			<RegExp input="$$1" output="&lt;chain function=&quot;GetTVDBWideBanners&quot;&gt;\1&lt;/chain&gt;" dest="5+">
 				<expression>"tvdb_id":([0-9]+)</expression>
 			</RegExp>
+			<RegExp conditional="fanarttvart" input="$$1" output="&lt;chain function=&quot;GetFanartTvArt&quot;&gt;\1&lt;/chain&gt;" dest="5+">
+				<expression>"tvdb_id":([0-9]+)</expression>
+			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
 	</ParseArt>
 	<GetSeasonArt clearbuffers="no" dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
+			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;https://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
 				<expression>^([0-9]+)\|</expression>
 			</RegExp>
 			<RegExp input="$$1" output="\1" dest="10">
 				<expression>\|([0-9]+)$</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseSeasonArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
+			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseSeasonArt&quot;&gt;https://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=credits,external_ids,images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
 				<expression>^([0-9]+)\|([0-9]+)$</expression>
 			</RegExp>
 			<expression noclean="1" />
@@ -583,29 +579,21 @@
 				<expression repeat="yes">"file_path":"([^"]*)","height":[0-9]+,"iso_639_1":(?!"$INFO[language]")</expression>
 			</RegExp>
 			<expression noclean="1" />
-		</RegExp>	
+		</RegExp>
 	</ParseSeasonArt>
-	<GetEpisodeArt dest="3" clearbuffers="no">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;url function=&quot;ParseTMDBBaseImageURL&quot; cache=&quot;tmdb-config.json&quot;&gt;http://api.themoviedb.org/3/configuration?api_key=6a5be4999abf74eba1f9a8311294c267&lt;/url&gt;" dest="5">
-				<expression>^([0-9]+)\|</expression>
-			</RegExp>
-			<RegExp input="$$1" output="&lt;url cache=&quot;tmdb-\1-$INFO[language]-season-\2.json&quot; function=&quot;ParseEpisodeArt&quot;&gt;http://api.themoviedb.org/3/tv/\1/season/\2?api_key=6a5be4999abf74eba1f9a8311294c267&amp;amp;language=$INFO[language]&amp;amp;append_to_response=images&amp;amp;include_image_language=$INFO[language],en,null&lt;/url&gt;" dest="5+">
-				<RegExp input="$$1" output="\1" dest="11">
-					<expression>^[0-9]+\|[0-9]+\|([0-9]+)$</expression>
+	<ParseEpisodeArt dest="4">
+		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
+			<RegExp input="$$7" output="&lt;thumb&gt;$$20original\1&lt;/thumb&gt;" dest="5">
+				<RegExp input="$$6" output="\1" dest="7">
+					<RegExp input="$$1" output="\1" dest="6">
+						<expression clear="yes">"episode/$$11/images":(.*)</expression>
+					</RegExp>
+					<expression clear="yes">"stills":\[([^\]]*)\]</expression>
 				</RegExp>
-				<expression>^([0-9]+)\|([0-9]+)\|[0-9]+$</expression>
+				<expression repeat="yes">"file_path":"([^"]*)"</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
-	</GetEpisodeArt>
-	<ParseEpisodeArt dest="4">
-		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="4">
-			<RegExp input="$$1" output="&lt;thumb&gt;$$20original\1&lt;/thumb&gt;" dest="5">
-				<expression clear="yes">"episode_number":$$11,[^[]+,"still_path":"([^"]*)"</expression>
-			</RegExp>
-			<expression noclean="1" />
-		</RegExp>	
 	</ParseEpisodeArt>
 
 	<GetTVDBWideBanners dest="3">


### PR DESCRIPTION
### Description of changes:
Whole bunch of updates/fixes.  
Starting at the top:
1. Added the year to the search query.
2. Tidied GetSearchResults, and added results based on the "name" field when it differs from "original_name" (fixes https://forum.kodi.tv/showthread.php?tid=200504&pid=2927244#pid2927244 where other series' original_names are a closer match than the one intended).
3. Removed the unnecessary GetTVShowExtIDs function.  External ids are appended to the main details anyway.  They can added directly without downloading an extra file.
4. Same with GetIMDbTVShowRating.  The imdb id is already there, so the actual rating function can be called directly.
5. Same with ParseTVShowContentRating.  The content rating is already appended.
6. Changed the GetCast function to use the season files (with credits appended).  Sidesteps the fact that only the current season regulars are appended to the series details (fixes #170).
7. Moved the call to GetFanartTvArt into ParseArt, so that it is run whenever GetArt is, and so that it gets listed after the tmdb artwork (which should get top billing in a tmdb scraper).
8. Moved the tmdbart conditional into ParseArt.  Since GetArt gets called directly by Kodi anyway, the conditional would otherwise just be ignored after the initial scrape.
9. Changed the episodeguide URL to keep the appended data, and also added the missing appended data to the ParseArt URL.  Possibly the source of the belief that separate functions were needed for ids and ratings?  If you refresh a series shortly after adding a new episode or after GetArt has run, the cached unappended file would be re-used, so you'd lose external ids and content ratings.
10. Removed the GetEpExtIDs, GetIMDbEpRating, and GetEpisodeArt functions in favor of a GetEpisodeExtraDetails function, which scrapes extra details for multiple episodes into a single file, avoiding the need to hit tmdb for each individual episode.
11. The replacement of GetEpisodeArt also comes with the inclusion of multiple episode thumbs (supercedes #147, which has a sort-of potential flaw in it).
12. Update URLs to use https instead of http (#178)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
