### PR TITLE
[metadata.tvmaze@matrix] 1.0.2+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.0.1+matrix.1"
+  version="1.0.2+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -22,9 +22,7 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.0.0:
-- Fixed a bug with empty ratings.
-- Added a workaround for a Kodi bug when episoude guide URL from NFO is passed to a scraper.
-- Artwork is now sorted by main property.</news>
+    <news>1.0.2:
+- Fixed a workaround for Kodi episodeguide URL bug.</news>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/__init__.py
+++ b/metadata.tvmaze/libs/__init__.py
@@ -1,5 +1,3 @@
 # coding: utf-8
 # Author: Roman Miroshnychenko aka Roman V.M.
 # E-mail: roman1972@gmail.com
-
-

--- a/metadata.tvmaze/libs/cache.py
+++ b/metadata.tvmaze/libs/cache.py
@@ -17,17 +17,43 @@
 
 """Cache-related functionality"""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
+
 import os
 from datetime import datetime, timedelta
-from six.moves import cPickle as pickle
-from .utils import get_cache_directory, logger
 
-CACHE_DIR = get_cache_directory()
-CACHING_DURATION = timedelta(hours=3)
+from six import PY2
+from six.moves import cPickle as pickle
+import xbmc
+import xbmcvfs
+
+from .utils import ADDON, logger
+
+try:
+    from typing import Optional, Text, Dict, Any  # pylint: disable=unused-import
+except ImportError:
+    pass
+
+
+CACHING_DURATION = timedelta(hours=3)  # type: timedelta
+
+
+def _get_cache_directory():  # pylint: disable=missing-docstring
+    # type: () -> Text
+    profile_dir = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+    if PY2:
+        profile_dir = profile_dir.decode('utf-8')
+    cache_dir = os.path.join(profile_dir, 'cache')
+    if not xbmcvfs.exists(cache_dir):
+        xbmcvfs.mkdir(cache_dir)
+    return cache_dir
+
+
+CACHE_DIR = _get_cache_directory()  # type: Text
 
 
 def cache_show_info(show_info):
+    # type: (Dict[Text, Any]) -> None
     """
     Save show_info dict to cache
     """
@@ -41,6 +67,7 @@ def cache_show_info(show_info):
 
 
 def load_show_info_from_cache(show_id):
+    # type: (Text) -> Optional[Dict[Text, Any]]
     """
     Load show info from a local cache
 

--- a/metadata.tvmaze/libs/debugger.py
+++ b/metadata.tvmaze/libs/debugger.py
@@ -14,18 +14,30 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Provides a context manager that writes extended debugging info
+in the Kodi log on unhandled exceptions
+"""
+from __future__ import absolute_import, unicode_literals
 
-from __future__ import absolute_import
 import inspect
 from contextlib import contextmanager
 from platform import uname
 from pprint import pformat
+
 import six
 import xbmc
+
 from .utils import logger
+
+try:
+    from typing import Text, Generator, Callable, Dict, Any  # pylint: disable=unused-import
+except ImportError:
+    pass
 
 
 def _format_vars(variables):
+    # type: (Dict[Text, Any]) -> Text
     """
     Format variables dictionary
 
@@ -45,6 +57,7 @@ def _format_vars(variables):
 
 @contextmanager
 def debug_exception(logger_func=logger.error):
+    # type: (Callable[[Text], None]) -> Generator[None]
     """
     Diagnostic helper context manager
 
@@ -79,8 +92,7 @@ def debug_exception(logger_func=logger.error):
         logger_func('System info: {0}'.format(uname()))
         logger_func('OS info: {0}'.format(xbmc.getInfoLabel('System.OSVersionInfo')))
         logger_func('Kodi version: {0}'.format(
-            xbmc.getInfoLabel('System.BuildVersion'))
-        )
+            xbmc.getInfoLabel('System.BuildVersion')))
         logger_func('File: {0}'.format(frame_info[1]))
         context = ''
         if frame_info[4] is not None:

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -17,64 +17,52 @@
 
 """Misc utils"""
 
-from __future__ import absolute_import
-import os
-from requests.sessions import Session
-from six import PY2, text_type
-import xbmc
-from xbmcaddon import Addon
-import xbmcvfs
+from __future__ import absolute_import, unicode_literals
 
-HEADERS = (
-    ('User-Agent', 'Kodi scraper for tvmaze.com by Roman V.M.; roman1972@gmail.com'),
-    ('Accept', 'application/json'),
-)
+import xbmc
+from six import PY2, text_type, binary_type
+from xbmcaddon import Addon
+
+try:
+    from typing import Text, Optional, Any, Dict  # pylint: disable=unused-import
+except ImportError:
+    pass
 
 ADDON_ID = 'metadata.tvmaze'
 ADDON = Addon()
 
 
-class logger:
+class logger:  # pylint: disable=invalid-name,old-style-class,no-init,missing-docstring
     log_message_prefix = '[{} ({})]: '.format(ADDON_ID, ADDON.getAddonInfo('version'))
 
     @staticmethod
     def log(message, level=xbmc.LOGDEBUG):
+        # type: (Text, int) -> None
+        if isinstance(message, binary_type):
+            message = message.decode('utf-8')
+        message = logger.log_message_prefix + message
         if PY2 and isinstance(message, text_type):
             message = message.encode('utf-8')
-        message = logger.log_message_prefix + message
         xbmc.log(message, level)
 
     @staticmethod
     def notice(message):
+        # type: (Text) -> None
         logger.log(message, xbmc.LOGNOTICE)
 
     @staticmethod
     def error(message):
+        # type: (Text) -> None
         logger.log(message, xbmc.LOGERROR)
 
     @staticmethod
     def debug(message):
+        # type: (Text) -> None
         logger.log(message, xbmc.LOGDEBUG)
 
 
-def get_requests_session():
-    """Create requests Session"""
-    session = Session()
-    session.headers.update(dict(HEADERS))
-    return session
-
-
-def get_cache_directory():
-    profile_dir = xbmc.translatePath(ADDON.getAddonInfo('profile'))
-    if PY2:
-        profile_dir = profile_dir.decode('utf-8')
-    cache_dir = os.path.join(profile_dir, 'cache')
-    if not xbmcvfs.exists(cache_dir):
-        xbmcvfs.mkdir(cache_dir)
-    return cache_dir
-
-
 def safe_get(dct, key, default=None):
+    # type: (Dict[Text, Any], Text, Any) -> Any
     """
     Get a key from dict
 

--- a/metadata.tvmaze/main.py
+++ b/metadata.tvmaze/main.py
@@ -14,9 +14,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-docstring
 
 from __future__ import absolute_import
+
 import sys
+
 from libs.actions import router
 from libs.debugger import debug_exception
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.0.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.0.2:
- Fixed a workaround for Kodi episodeguide URL bug.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
