### PR TITLE
[metadata.themoviedb.org.python@leia] 1.2.0

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.1.1"
+       version="1.2.0"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -15,14 +15,9 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.1.1 (2020-03-01)
-- Fix: release fixup
-
-v1.1.0 (2020-02-26)
-- Feature: option to add plot keywords from TMDB as tags
-
-v1.0.0 (2020-01-26)
-- Feature: option to enable/disable IMDB and Trakt ratings</news>
+    <news>v1.2.0 (2020-05-25)
+- Feature: add extended artwork from Fanart.tv
+- Feature: separate 'fanart' images with language to 'landscape' art type</news>
     <summary lang="af_ZA">TMDB Fliek Skraper</summary>
     <summary lang="be_BY">TMDB Movie Scraper</summary>
     <summary lang="bg_BG">Сваля инф. за филми от TMDB</summary>

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/fanarttv.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/fanarttv.py
@@ -1,0 +1,101 @@
+import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout, RequestException
+try:
+    from urllib import quote
+except ImportError: # py2 / py3
+    from urllib.parse import quote
+
+API_KEY = '384afe262ee0962545a752ff340e3ce4'
+API_URL = 'https://webservice.fanart.tv/v3/movies/{}'
+
+ARTMAP = {
+    'movielogo': 'clearlogo',
+    'hdmovielogo': 'clearlogo',
+    'hdmovieclearart': 'clearart',
+    'movieart': 'clearart',
+    'moviedisc': 'discart',
+    'moviebanner': 'banner',
+    'moviethumb': 'landscape',
+    'moviebackground': 'fanart',
+    'movieposter': 'poster'
+}
+
+def get_details(uniqueids, clientkey, language, set_tmdbid):
+    media_id = _get_mediaid(uniqueids)
+    if not media_id:
+        return {}
+
+    movie_data = _get_data(media_id, clientkey)
+    movieset_data = _get_data(set_tmdbid, clientkey)
+    if not movie_data and not movieset_data:
+        return {}
+
+    movie_art = {}
+    movieset_art = {}
+    if movie_data:
+        movie_art = _parse_data(movie_data, language)
+    if movieset_data:
+        movieset_art = _parse_data(movieset_data, language)
+        movieset_art = {'set.' + key: value for key, value in movieset_art.items()}
+
+    available_art = movie_art
+    available_art.update(movieset_art)
+
+    return {'available_art': available_art}
+
+def _get_mediaid(uniqueids):
+    for source in ('tmdb', 'imdb', 'unknown'):
+        if source in uniqueids:
+            return uniqueids[source]
+
+def _get_data(media_id, clientkey):
+    headers = {'api-key': API_KEY}
+    if clientkey:
+        headers['client-key'] = clientkey
+
+    try:
+        response = requests.get(API_URL.format(media_id), headers=headers)
+    except (Timeout, RequestsConnectionError, RequestException) as ex:
+        return _format_error_message(ex)
+
+    if not response or not response.status_code == 200:
+        return None
+
+    return response.json()
+
+def _format_error_message(ex):
+    message = type(ex).__name__
+    if hasattr(ex, 'message'):
+        message += ": {0}".format(ex.message)
+    return {'error': message}
+
+def _parse_data(data, language):
+    result = {}
+    for arttype, artlist in data.items():
+        if arttype not in ARTMAP:
+            continue
+        for image in artlist:
+            image_lang = _get_imagelanguage(arttype, image)
+            if image_lang and image_lang != language:
+                continue
+
+            generaltype = ARTMAP[arttype]
+            if generaltype == 'poster' and not image_lang:
+                generaltype = 'keyart'
+            if artlist and generaltype not in result:
+                result[generaltype] = []
+
+            url = quote(image['url'], safe="%/:=&?~#+!$,;'@()*[]")
+            resultimage = {'url': url, 'preview': url.replace('.fanart.tv/fanart/', '.fanart.tv/preview/')}
+            result[generaltype].append(resultimage)
+
+    return result
+
+def _get_imagelanguage(arttype, image):
+    if 'lang' not in image or arttype == 'moviebackground':
+        return None
+    if arttype in ('movielogo', 'hdmovielogo', 'hdmovieclearart', 'movieart', 'moviebanner',
+            'moviethumb', 'moviedisc'):
+        return image['lang'] if image['lang'] not in ('', '00') else 'en'
+    # movieposter may or may not have a title and thus need a language
+    return image['lang'] if image['lang'] not in ('', '00') else None

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
@@ -112,8 +112,11 @@ class TMDBMovieScraper(object):
         ]
         available_art = _parse_artwork(movie_fallback, collection_fallback, self.urls, self.language)
 
+        _info = {'set_tmdbid': movie['belongs_to_collection'].get('id')
+            if movie['belongs_to_collection'] else None}
+
         return {'info': info, 'ratings': ratings, 'uniqueids': uniqueids, 'cast': cast,
-            'available_art': available_art}
+            'available_art': available_art, '_info': _info}
 
 def _parse_media_id(title):
     if title.startswith('tt') and title[2:].isdigit():
@@ -147,36 +150,41 @@ def _get_moviecollection(collection_id, language=None):
 
 def _parse_artwork(movie, collection, urlbases, language):
     posters = []
+    landscape = []
     fanart = []
     if 'images' in movie:
-        posters = _get_posters(movie['images']['posters'], urlbases, language)
-        fanart = _get_images(movie['images']['backdrops'], urlbases, language)
+        posters = _get_images_with_fallback(movie['images']['posters'], urlbases, language)
+        landscape = _get_images(movie['images']['backdrops'], urlbases, language)
+        fanart = _get_images(movie['images']['backdrops'], urlbases, None)
 
     setposters = []
+    setlandscape = []
     setfanart = []
     if collection and 'images' in collection:
-        setposters = _get_posters(collection['images']['posters'], urlbases, language)
-        setfanart = _get_images(collection['images']['backdrops'], urlbases, language)
+        setposters = _get_images_with_fallback(collection['images']['posters'], urlbases, language)
+        setlandscape = _get_images(collection['images']['backdrops'], urlbases, language)
+        setfanart = _get_images(collection['images']['backdrops'], urlbases, None)
 
-    return {'poster': posters, 'fanart': fanart, 'set.poster': setposters, 'set.fanart': setfanart}
+    return {'poster': posters, 'landscape': landscape, 'fanart': fanart,
+        'set.poster': setposters, 'set.landscape': setlandscape, 'set.fanart': setfanart}
 
-def _get_posters(posterlist, urlbases, language):
-    posters = _get_images(posterlist, urlbases, language)
+def _get_images_with_fallback(imagelist, urlbases, language, language_fallback='en'):
+    images = _get_images(imagelist, urlbases, language)
 
-    # Add backup English posters
-    if language != 'en':
-        posters.extend(_get_images(posterlist, urlbases, 'en'))
+    # Add backup images
+    if language != language_fallback:
+        images.extend(_get_images(imagelist, urlbases, language_fallback))
 
-    # Add any poster if nothing set so far
-    if not posters:
-        posters = _get_images(posterlist, urlbases)
+    # Add any images if nothing set so far
+    if not images:
+        images = _get_images(imagelist, urlbases)
 
-    return posters
+    return images
 
-def _get_images(imagelist, urlbases, language=None):
+def _get_images(imagelist, urlbases, language='_any'):
     result = []
     for img in imagelist:
-        if language and img['iso_639_1'] and img['iso_639_1'] != language:
+        if language != '_any' and img['iso_639_1'] != language:
             continue
         result.append({
             'url': urlbases['original'] + img['file_path'],
@@ -196,8 +204,8 @@ def _load_base_urls(url_settings):
             float(last_updated) < _get_date_numeric(datetime.now() - timedelta(days=30)):
         conf = tmdbsimple.Configuration().info()
         if conf:
-            urls['original'] = conf['images']['base_url'] + 'original'
-            urls['preview'] = conf['images']['base_url'] + 'w780'
+            urls['original'] = conf['images']['secure_base_url'] + 'original'
+            urls['preview'] = conf['images']['secure_base_url'] + 'w780'
             url_settings.setSetting('originalUrl', urls['original'])
             url_settings.setSetting('previewUrl', urls['preview'])
             url_settings.setSetting('lastUpdated', str(_get_date_numeric(datetime.now())))

--- a/metadata.themoviedb.org.python/python/scraper_config.py
+++ b/metadata.themoviedb.org.python/python/scraper_config.py
@@ -7,6 +7,42 @@ def configure_scraped_details(details, settings):
     details = _configure_tags(details, settings)
     return details
 
+def configure_tmdb_artwork(details, settings):
+    if 'available_art' not in details:
+        return details
+
+    art = details['available_art']
+    if not settings.getSettingBool('fanart'):
+        if 'fanart' in art:
+            del art['fanart']
+        if 'set.fanart' in art:
+            del art['set.fanart']
+    if not settings.getSettingBool('landscape'):
+        if 'landscape' in art:
+            del art['landscape']
+        if 'set.landscape' in art:
+            del art['set.landscape']
+
+    return details
+
+_fanarttv_arttypes = ['fanart', 'poster', 'clearlogo', 'clearart', 'discart', 'banner', 'landscape', 'keyart']
+_fanarttv_arttypes += ['set.' + t for t in _fanarttv_arttypes]
+def configure_fanarttv_artwork(details, settings):
+    if 'available_art' not in details:
+        return details
+    art = details['available_art']
+    for arttype in _fanarttv_arttypes:
+        if arttype in art and not settings.getSettingBool('enable_fanarttv_' + arttype):
+            del art[arttype]
+
+    return details
+
+def is_fanarttv_configured(settings):
+    for arttype in _fanarttv_arttypes:
+        if settings.getSettingBool('enable_fanarttv_' + arttype):
+            return True
+    return False
+
 def _configure_rating_prefix(details, settings):
     if details['info'].get('mpaa'):
         details['info']['mpaa'] = settings.getSettingString('certprefix') + details['info']['mpaa']

--- a/metadata.themoviedb.org.python/python/scraper_datahelper.py
+++ b/metadata.themoviedb.org.python/python/scraper_datahelper.py
@@ -27,6 +27,18 @@ def combine_scraped_details_info_and_ratings(original_details, additional_detail
             update_or_set(original_details, 'ratings', additional_details['ratings'])
     return original_details
 
+def combine_scraped_details_available_artwork(original_details, additional_details):
+    if additional_details and additional_details.get('available_art'):
+        available_art = additional_details['available_art']
+        if not original_details.get('available_art'):
+            original_details['available_art'] = available_art
+        else:
+            for arttype, artlist in available_art.items():
+                original_details['available_art'][arttype] = \
+                    artlist + original_details['available_art'].get(arttype, [])
+
+    return original_details
+
 def find_uniqueids_in_text(input_text):
     result = {}
     res = re.search(r'(themoviedb.org/movie/)([0-9]+)', input_text)

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#30000"
-msgid "Enable Fanart"
+msgid "Enable fanart from TMDb"
 msgstr ""
 
 msgctxt "#30001"
@@ -62,4 +62,80 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Add keywords as tags"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Enable landscape from TMDb"
+msgstr ""
+
+msgctxt "#30100"
+msgid "Language for Fanart.tv artwork"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Fanart.tv personal API key (optional)"
+msgstr ""
+
+msgctxt "#30102"
+msgid "Enable fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30103"
+msgid "Enable poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30104"
+msgid "Enable clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30105"
+msgid "Enable clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30106"
+msgid "Enable discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30107"
+msgid "Enable banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30108"
+msgid "Enable landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30109"
+msgid "Enable set fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30110"
+msgid "Enable set poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30111"
+msgid "Enable set clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30112"
+msgid "Enable set clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30113"
+msgid "Enable set discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30114"
+msgid "Enable set banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30115"
+msgid "Enable set landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30116"
+msgid "Enable keyart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30117"
+msgid "Enable set keyart from Fanart.tv"
 msgstr ""

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_nz/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_nz/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#30000"
-msgid "Enable Fanart"
+msgid "Enable fanart from TMDb"
 msgstr ""
 
 msgctxt "#30001"
@@ -62,4 +62,80 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Add keywords as tags"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Enable landscape from TMDb"
+msgstr ""
+
+msgctxt "#30100"
+msgid "Language for Fanart.tv artwork"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Fanart.tv personal API key (optional)"
+msgstr ""
+
+msgctxt "#30102"
+msgid "Enable fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30103"
+msgid "Enable poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30104"
+msgid "Enable clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30105"
+msgid "Enable clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30106"
+msgid "Enable discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30107"
+msgid "Enable banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30108"
+msgid "Enable landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30109"
+msgid "Enable set fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30110"
+msgid "Enable set poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30111"
+msgid "Enable set clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30112"
+msgid "Enable set clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30113"
+msgid "Enable set discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30114"
+msgid "Enable set banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30115"
+msgid "Enable set landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30116"
+msgid "Enable keyart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30117"
+msgid "Enable set keyart from Fanart.tv"
 msgstr ""

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_us/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_us/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#30000"
-msgid "Enable Fanart"
+msgid "Enable fanart from TMDb"
 msgstr ""
 
 msgctxt "#30001"
@@ -62,4 +62,80 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Add keywords as tags"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Enable landscape from TMDb"
+msgstr ""
+
+msgctxt "#30100"
+msgid "Language for Fanart.tv artwork"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Fanart.tv personal API key (optional)"
+msgstr ""
+
+msgctxt "#30102"
+msgid "Enable fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30103"
+msgid "Enable poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30104"
+msgid "Enable clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30105"
+msgid "Enable clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30106"
+msgid "Enable discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30107"
+msgid "Enable banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30108"
+msgid "Enable landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30109"
+msgid "Enable set fanart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30110"
+msgid "Enable set poster from Fanart.tv"
+msgstr ""
+
+msgctxt "#30111"
+msgid "Enable set clearlogo from Fanart.tv"
+msgstr ""
+
+msgctxt "#30112"
+msgid "Enable set clearart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30113"
+msgid "Enable set discart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30114"
+msgid "Enable set banner from Fanart.tv"
+msgstr ""
+
+msgctxt "#30115"
+msgid "Enable set landscape from Fanart.tv"
+msgstr ""
+
+msgctxt "#30116"
+msgid "Enable keyart from Fanart.tv"
+msgstr ""
+
+msgctxt "#30117"
+msgid "Enable set keyart from Fanart.tv"
 msgstr ""

--- a/metadata.themoviedb.org.python/resources/settings.xml
+++ b/metadata.themoviedb.org.python/resources/settings.xml
@@ -1,18 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <settings>
-    <setting label="30005" type="bool" id="keeporiginaltitle" default="false"/>
-    <setting label="30000" type="bool" id="fanart" default="true"/>
-    <setting label="30004" type="bool" id="trailer" default="true"/>
-	<setting label="30002" type="select" values="ar-AE|ar-SA|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|eu-ES|fa|fa-ir|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-br|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-tw|zh-hk" id="language" default="en"/>
-    <setting label="30006" type="select" values="au|bg|br|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
-    <setting label="30008" type="text" id="certprefix" default="Rated " />
-    <setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>
-    <setting label="30007" type="bool" id="imdbanyway" visible="!eq(-1,1)" default="false"/>
-    <setting label="30010" type="bool" id="traktanyway" visible="!eq(-2,2)" default="false"/>
-    <setting label="30009" type="bool" id="multiple_studios" default="false" />
-    <setting label="30011" type="bool" id="add_tags" default="true" />
-    <!-- For add-on inner workings -->
-    <setting id="lastUpdated" type="text" default="0" visible="false" />
-    <setting id="originalUrl" type="text" default="" visible="false" />
-    <setting id="previewUrl" type="text" default="" visible="false" />
+	<category label="$LOCALIZE[128]">
+		<setting label="30005" type="bool" id="keeporiginaltitle" default="false"/>
+		<setting label="30000" type="bool" id="fanart" default="true"/>
+		<setting label="30012" type="bool" id="landscape" default="true"/>
+		<setting label="30004" type="bool" id="trailer" default="true"/>
+		<setting label="30002" type="select" values="ar-AE|ar-SA|be-BY|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|eu-ES|fa|fa-ir|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-br|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-tw|zh-hk" id="language" default="en"/>
+		<setting label="30006" type="select" values="au|bg|br|by|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
+		<setting label="30008" type="text" id="certprefix" default="Rated " />
+		<setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>
+		<setting label="30007" type="bool" id="imdbanyway" visible="!eq(-1,1)" default="false"/>
+		<setting label="30010" type="bool" id="traktanyway" visible="!eq(-2,2)" default="false"/>
+		<setting label="30009" type="bool" id="multiple_studios" default="false" />
+		<setting label="30011" type="bool" id="add_tags" default="true" />
+		<!-- For add-on inner workings -->
+		<setting id="lastUpdated" type="text" default="0" visible="false" />
+		<setting id="originalUrl" type="text" default="" visible="false" />
+		<setting id="previewUrl" type="text" default="" visible="false" />
+	</category>
+	<category label="Fanart.tv">
+        <setting id="fanarttv_language" label="30100" type="select" default="en" values="en|fr|de|ja|zh|es|it|pt|sv|ru|nl|ar|ko|no|hu|da|hi|is|pl|he|bg|fi|ml" />
+		<setting label="30102" type="bool" id="enable_fanarttv_fanart" default="false"/>
+		<setting label="30103" type="bool" id="enable_fanarttv_poster" default="false"/>
+		<setting label="30116" type="bool" id="enable_fanarttv_keyart" default="false"/>
+		<setting label="30104" type="bool" id="enable_fanarttv_clearlogo" default="false"/>
+		<setting label="30105" type="bool" id="enable_fanarttv_clearart" default="false"/>
+		<setting label="30106" type="bool" id="enable_fanarttv_discart" default="false"/>
+		<setting label="30107" type="bool" id="enable_fanarttv_banner" default="false"/>
+		<setting label="30108" type="bool" id="enable_fanarttv_landscape" default="false"/>
+		<setting label="30109" type="bool" id="enable_fanarttv_set.fanart" default="false"/>
+		<setting label="30110" type="bool" id="enable_fanarttv_set.poster" default="false"/>
+		<setting label="30117" type="bool" id="enable_fanarttv_set.keyart" default="false"/>
+		<setting label="30111" type="bool" id="enable_fanarttv_set.clearlogo" default="false"/>
+		<setting label="30112" type="bool" id="enable_fanarttv_set.clearart" default="false"/>
+		<setting label="30113" type="bool" id="enable_fanarttv_set.discart" default="false"/>
+		<setting label="30114" type="bool" id="enable_fanarttv_set.banner" default="false"/>
+		<setting label="30115" type="bool" id="enable_fanarttv_set.landscape" default="false"/>
+		<setting label="30101" type="text" id="fanarttv_clientkey" default="" />
+	</category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 1.2.0
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v1.2.0 (2020-05-25)
- Feature: add extended artwork from Fanart.tv
- Feature: separate 'fanart' images with language to 'landscape' art type

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
