### PR TITLE
[metadata.tvmaze@leia] 1.0.3

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.0.2"
+  version="1.0.3"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -22,7 +22,10 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.0.2:
+    <news>1.0.3:
+- Fixed a crash with non-ASCII studio name.
+
+1.0.2:
 - Fixed a workaround for Kodi episodeguide URL bug.</news>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/data_utils.py
+++ b/metadata.tvmaze/libs/data_utils.py
@@ -17,7 +17,7 @@
 
 """Functions to process data"""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import re
 from collections import OrderedDict, namedtuple

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -32,7 +32,7 @@ ADDON_ID = 'metadata.tvmaze'
 ADDON = Addon()
 
 
-class logger:  # pylint: disable=invalid-name,old-style-class,no-init,missing-docstring
+class logger:
     log_message_prefix = '[{} ({})]: '.format(ADDON_ID, ADDON.getAddonInfo('version'))
 
     @staticmethod


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.0.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.0.3:
- Fixed a crash with non-ASCII studio name.

1.0.2:
- Fixed a workaround for Kodi episodeguide URL bug.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
