### PR TITLE
[metadata.tvmaze@leia] 1.0.4

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.0.3"
+  version="1.0.4"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -22,7 +22,10 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.0.3:
+    <news>1.0.4:
+- Fixed a crash with non-ASCII show title in Python 2
+
+1.0.3:
 - Fixed a crash with non-ASCII studio name.
 
 1.0.2:

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -21,16 +21,16 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 
+import six
 import xbmcgui
 import xbmcplugin
-from six import itervalues
 from six.moves import urllib_parse
 
 from . import tvmaze, data_utils
 from .utils import logger
 
 try:
-    from typing import Optional, Text  # pylint: disable=unused-import
+    from typing import Optional, Text, Union, ByteString  # pylint: disable=unused-import
 except ImportError:
     pass
 
@@ -38,8 +38,10 @@ HANDLE = int(sys.argv[1])  # type: int
 
 
 def find_show(title, year=None):
-    # type: (Text, Optional[Text]) -> None
+    # type: (Union[Text, bytes], Optional[Text]) -> None
     """Find a show by title"""
+    if not isinstance(title, six.text_type):
+        title = title.decode('utf-8')
     logger.debug('Searching for TV show {} ({})'.format(title, year))
     search_results = tvmaze.search_show(title)
     if year is not None:
@@ -129,7 +131,7 @@ def get_episode_list(show_id):  # pylint: disable=missing-docstring
     else:
         show_info = tvmaze.load_show_info(show_id)
     if show_info is not None:
-        for episode in itervalues(show_info['episodes']):
+        for episode in six.itervalues(show_info['episodes']):
             list_item = xbmcgui.ListItem(episode['name'], offscreen=True)
             list_item = data_utils.add_episode_info(list_item, episode, full_info=False)
             encoded_ids = urllib_parse.urlencode(

--- a/metadata.tvmaze/libs/data_utils.py
+++ b/metadata.tvmaze/libs/data_utils.py
@@ -59,7 +59,9 @@ def process_episode_list(show_info, episode_list):
     episodes = OrderedDict()
     specials_list = []
     for episode in episode_list:
-        if episode['number']:
+        # xbmc/video/VideoInfoScanner.cpp ~ line 1010
+        # "episode 0 with non-zero season is valid! (e.g. prequel episode)"
+        if episode['number'] is not None:
             episodes[episode['id']] = episode
         else:
             specials_list.append(episode)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.0.4
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.0.4:
- Fixed a crash with non-ASCII show title in Python 2

1.0.3:
- Fixed a crash with non-ASCII studio name.

1.0.2:
- Fixed a workaround for Kodi episodeguide URL bug.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
