### PR TITLE
[metadata.themoviedb.org.python@leia] 1.2.1

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.2.0"
+       version="1.2.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -15,7 +15,11 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.2.0 (2020-05-25)
+    <news>v1.2.1 (2020-08-08)
+- Fix: Prefer movies that exactly match search title and year
+- Fix: Change 'landscape from TMDb' option disabled behavior to keep titled fanart
+
+v1.2.0 (2020-05-25)
 - Feature: add extended artwork from Fanart.tv
 - Feature: separate 'fanart' images with language to 'landscape' art type</news>
     <summary lang="af_ZA">TMDB Fliek Skraper</summary>

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
@@ -36,6 +36,15 @@ class TMDBMovieScraper(object):
                 return _format_error_message(ex)
             result = response['results']
         urls = self.urls
+
+        def is_best(item):
+            return item['title'].lower() == title and (
+                not year or item.get('release_date', '').startswith(year))
+        if result and not is_best(result[0]):
+            best_first = next((item for item in result if is_best(item)), None)
+            if best_first:
+                result = [best_first] + [item for item in result if item is not best_first]
+
         for item in result:
             if item.get('poster_path'):
                 item['poster_path'] = urls['preview'] + item['poster_path']
@@ -225,7 +234,7 @@ def _get_cast_members(casts, casttype, department, jobs):
     result = []
     if casttype in casts:
         for cast in casts[casttype]:
-            if cast['department'] == department and cast['job'] in jobs:
+            if cast['department'] == department and cast['job'] in jobs and cast['name'] not in result:
                 result.append(cast['name'])
     return result
 

--- a/metadata.themoviedb.org.python/python/scraper_config.py
+++ b/metadata.themoviedb.org.python/python/scraper_config.py
@@ -12,15 +12,20 @@ def configure_tmdb_artwork(details, settings):
         return details
 
     art = details['available_art']
-    if not settings.getSettingBool('fanart'):
+    fanart_enabled = settings.getSettingBool('fanart')
+    if not fanart_enabled:
         if 'fanart' in art:
             del art['fanart']
         if 'set.fanart' in art:
             del art['set.fanart']
     if not settings.getSettingBool('landscape'):
         if 'landscape' in art:
+            if fanart_enabled:
+                art['fanart'] = art.get('fanart', []) + art['landscape']
             del art['landscape']
         if 'set.landscape' in art:
+            if fanart_enabled:
+                art['set.fanart'] = art.get('set.fanart', []) + art['set.landscape']
             del art['set.landscape']
 
     return details

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_nz/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_nz/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"

--- a/metadata.themoviedb.org.python/resources/language/resource.language.en_us/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.en_us/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"

--- a/metadata.themoviedb.org.python/resources/settings.xml
+++ b/metadata.themoviedb.org.python/resources/settings.xml
@@ -5,7 +5,7 @@
 		<setting label="30000" type="bool" id="fanart" default="true"/>
 		<setting label="30012" type="bool" id="landscape" default="true"/>
 		<setting label="30004" type="bool" id="trailer" default="true"/>
-		<setting label="30002" type="select" values="ar-AE|ar-SA|be-BY|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|eu-ES|fa|fa-ir|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-br|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-tw|zh-hk" id="language" default="en"/>
+		<setting label="30002" type="select" values="ar-AE|ar-SA|be-BY|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|et-EE|eu-ES|fa|fa-IR|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-BR|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-TW|zh-HK" id="language" default="en"/>
 		<setting label="30006" type="select" values="au|bg|br|by|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
 		<setting label="30008" type="text" id="certprefix" default="Rated " />
 		<setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 1.2.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v1.2.1 (2020-08-08)
- Fix: Prefer movies that exactly match search title and year
- Fix: Change 'landscape from TMDb' option disabled behavior to keep titled fanart

v1.2.0 (2020-05-25)
- Feature: add extended artwork from Fanart.tv
- Feature: separate 'fanart' images with language to 'landscape' art type

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
