### PR TITLE
[metadata.generic.albums] 1.0.13

### DIFF
--- a/metadata.generic.albums/addon.xml
+++ b/metadata.generic.albums/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="metadata.generic.albums" name="Generic Album Scraper" version="1.0.12" provider-name="Team Kodi">
+<addon id="metadata.generic.albums" name="Generic Album Scraper" version="1.0.13" provider-name="Team Kodi">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.generic.albums/changelog.txt
+++ b/metadata.generic.albums/changelog.txt
@@ -1,3 +1,7 @@
+v1.0.13
+- fix missing endOfDirectory() call when returning 0 results
+- scrape using mbalbumid only if we don't have a mbreleasegroupid
+
 v1.0.12
 - don't populate the art table, this is handled by kodi now
 

--- a/metadata.generic.albums/lib/scraper.py
+++ b/metadata.generic.albums/lib/scraper.py
@@ -124,11 +124,12 @@ class Scraper():
                 if not mbreleasegroupid:
                     result = self.get_details(mbalbumid, 'musicbrainz', details)
                     if not result:
-                        return
-                    mbreleasegroupid = details['musicbrainz']['mbreleasegroupid']
-                    artist = details['musicbrainz']['artist_description']
-                    album = details['musicbrainz']['album']
-                    scrapers = [[mbreleasegroupid, 'theaudiodb'], [mbreleasegroupid, 'fanarttv'], [mbreleasegroupid, 'coverarchive']]
+                        scrapers = [[mbalbumid, 'musicbrainz']]
+                    else:
+                        mbreleasegroupid = details['musicbrainz']['mbreleasegroupid']
+                        artist = details['musicbrainz']['artist_description']
+                        album = details['musicbrainz']['album']
+                        scrapers = [[mbreleasegroupid, 'theaudiodb'], [mbreleasegroupid, 'fanarttv'], [mbreleasegroupid, 'coverarchive']]
                 else:
                     scrapers = [[mbalbumid, 'musicbrainz'], [mbreleasegroupid, 'theaudiodb'], [mbreleasegroupid, 'fanarttv'], [mbreleasegroupid, 'coverarchive']]
                 # get musicbrainz links to other metadata sites


### PR DESCRIPTION
### Description
fixes a bug that would lock up scraping when your internet connection goes down.

thx @DaveTBlake for catching this issue.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
