### PR TITLE
[metadata.tvmaze@matrix] 1.0.5+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.0.4+matrix.1"
+  version="1.0.5+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -15,20 +15,17 @@
     <description lang="en_GB">TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
 We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.</description>
     <platform>all</platform>
-    <license>GPL v3.0</license>
+    <license>GPL-3.0-or-later</license>
     <assets>
       <icon>resources/icon.png</icon>
       <fanart>resources/background.jpg</fanart>
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.0.4:
-- Fixed a crash with non-ASCII show title in Python 2
+    <news>1.0.5:
+- Fixed a rare crash on some Python 3.x versions.
 
-1.0.3:
-- Fixed a crash with non-ASCII studio name.
-
-1.0.2:
-- Fixed a workaround for Kodi episodeguide URL bug.</news>
+1.0.4:
+- Fixed a crash with non-ASCII show title in Python 2</news>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/cache.py
+++ b/metadata.tvmaze/libs/cache.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 from datetime import datetime, timedelta
 
-from six import PY2
+from six import PY2, PY3
 from six.moves import cPickle as pickle
 import xbmc
 import xbmcvfs
@@ -77,7 +77,11 @@ def load_show_info_from_cache(show_id):
     file_name = str(show_id) + '.pickle'
     try:
         with open(os.path.join(CACHE_DIR, file_name), 'rb') as fo:
-            cache = pickle.load(fo)
+            load_kwargs = {}
+            if PY3:
+                # https://forum.kodi.tv/showthread.php?tid=349813&pid=2970989#pid2970989
+                load_kwargs['encoding'] = 'bytes'
+            cache = pickle.load(fo, **load_kwargs)
         if datetime.now() - cache['timestamp'] > CACHING_DURATION:
             return None
         return cache['show_info']

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -46,9 +46,9 @@ class logger:
         xbmc.log(message, level)
 
     @staticmethod
-    def notice(message):
+    def info(message):
         # type: (Text) -> None
-        logger.log(message, xbmc.LOGNOTICE)
+        logger.log(message, xbmc.LOGINFO)
 
     @staticmethod
     def error(message):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.0.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.0.5:
- Fixed a rare crash on some Python 3.x versions.

1.0.4:
- Fixed a crash with non-ASCII show title in Python 2

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
