### PR TITLE
[Fix] Scrape artists where all or part of the name is enclosed in double quotes

### DIFF
--- a/metadata.musicvideos.theaudiodb.com/addon.xml
+++ b/metadata.musicvideos.theaudiodb.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.musicvideos.theaudiodb.com"
        name="TheAudioDb.com for Music Videos"
-       version="1.3.4"
+       version="1.3.5"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/metadata.musicvideos.theaudiodb.com/changelog.txt
+++ b/metadata.musicvideos.theaudiodb.com/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.3.5[/B]
+- Fixed scraping of artist name when enclosed in "
+
 [B]1.3.4[/B]
 - changed: switched to https
 

--- a/metadata.musicvideos.theaudiodb.com/tadb.xml
+++ b/metadata.musicvideos.theaudiodb.com/tadb.xml
@@ -25,7 +25,7 @@
 	<GetSearchResults dest="3">
 		<RegExp input="$$5" output="&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" dest="3">
 			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\5 - \3 [\4]&lt;/title&gt;&lt;url cache=&quot;tadb-\1.json&quot;&gt;https://www.theaudiodb.com/api/v1/json/18626d636d76696473706d/track.php?h=\1&lt;/url&gt;&lt;/entity&gt;" dest="5">
-				<expression repeat="yes" clear="yes" fixchars="1" noclean="1">idTrack&quot;:&quot;([^&quot;]*)&quot;,&quot;idAlbum&quot;:&quot;([^&quot;]*).*?&quot;strTrack&quot;:&quot;([^&quot;]*)&quot;,&quot;strAlbum&quot;:&quot;([^&quot;]*)&quot;,&quot;strArtist&quot;:&quot;([^&quot;]*)</expression>
+				<expression repeat="yes" clear="yes" fixchars="1" noclean="1">idTrack&quot;:&quot;([^&quot;]*)&quot;,&quot;idAlbum&quot;:&quot;([^&quot;]*).*?&quot;strTrack&quot;:&quot;([^&quot;]*)&quot;,&quot;strAlbum&quot;:&quot;([^&quot;]*)&quot;,&quot;strArtist&quot;:&quot;(.*?)&quot;,&quot;</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -36,7 +36,7 @@
 				<expression fixchars="1" noclean="1">strTrack&quot;:&quot;([^&quot;]*)&quot;</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;artist&gt;\1&lt;/artist&gt;" dest="5+">
-				<expression fixchars="1" noclean="1">strArtist&quot;:&quot;([^&quot;]*)&quot;</expression>
+				<expression fixchars="1" noclean="1">strArtist&quot;:&quot;(.*?)&quot;,&quot;</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;album&gt;\1&lt;/album&gt;" dest="5+">
 				<expression fixchars="1" noclean="1">strAlbum&quot;:&quot;([^&quot;]*)&quot;</expression>


### PR DESCRIPTION
### Description
Fixes an issue where trying to scrape an artist like `"Weird Al" Yankovic` would return `\` as the artist name.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
