### PR TITLE
[metadata.themoviedb.org.python@matrix] 1.3.2+matrix.1

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.3.1+matrix.1"
+       version="1.3.2+matrix.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,15 +11,14 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.3.1 (2020-11-02)
-- Change: simplify artwork selection options
-- Fix: strip region to pick correct poster language
+    <news>v1.3.2 (2021-03-13)
+- Change: improve best match selection
+- Change: poster language fallback to highest rated
+- Fix: handle errors when connecting to TMDB
 
-v1.3.0 (2020-10-04)
+v1.3.0 - v1.3.1
 - Change: removed dependencies on requests, tmdbsimple, and trakt modules
-- Change: images now returned with initial API call instead of during fallback
-- Change: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
-</news>
+- Change: simplify artwork selection options</news>
     <summary lang="af_ZA">TMDB Fliek Skraper</summary>
     <summary lang="be_BY">TMDB Movie Scraper</summary>
     <summary lang="bg_BG">Сваля инф. за филми от TMDB</summary>

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,0 +1,48 @@
+v1.3.2 (2021-03-13)
+- Change: improve best match selection
+- Change: poster language fallback to highest rated
+- Fix: handle errors when connecting to TMDB
+
+v1.3.1 (2020-11-02)
+- Change: simplify artwork selection options
+- Fix: strip region to pick correct poster language
+
+v1.3.0 (2020-10-04)
+- Change: removed dependencies on requests, tmdbsimple, and trakt modules
+- Change: images now returned with initial API call instead of during fallback
+- Change: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
+
+v1.2.1 (2020-08-08)
+- Fix: Prefer movies that exactly match search title and year
+- Fix: Change 'landscape from TMDb' option disabled behavior to keep titled fanart
+- Fix: Don't dupe Writers if listed with multiple jobs
+- Fix: Capitalize country code in all language options
+
+v1.2.0 (2020-05-25)
+- Feature: add extended artwork from Fanart.tv
+- Feature: separate 'fanart' images with language to 'landscape' art type
+
+v1.1.1 (2020-03-01)
+- Fix: release fixup
+
+v1.1.0 (2020-02-26)
+- Feature: option to add plot keywords from TMDB as tags
+
+v1.0.0 (2020-01-26)
+- Feature: option to enable/disable IMDB and Trakt ratings
+
+v0.7.0 (2020-01-11) - release candidate
+- Feature: add trakt rating
+- Feature: search by IMDB or TMDB ID
+- Fix: support path-specific settings
+
+v0.6.0 (2019-07-04)
+- Feature: add setting to configure certification prefix
+- Feature: add option to return single or multiple studios
+- Feature: add movie set overview and artwork
+- Fix: IMDB top 250 and ratings
+- Fix: parsing NFO file for URL / ID
+
+v0.5.0 (2019-06-09)
+- first Python version
+- early version mostly by @phate89, with an old version of tmdbsimple

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdbapi.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdbapi.py
@@ -121,12 +121,8 @@ def get_configuration():
 
 def _set_params(append_to_response, language):
     params = TMDB_PARAMS.copy()
-    img_lang = 'en,null'
     if language is not None:
         params['language'] = language
-        img_lang = '%s,en,null' % language[0:2]
     if append_to_response is not None:
         params['append_to_response'] = append_to_response
-        if 'images' in append_to_response:
-            params['include_image_language'] = img_lang
     return params


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 1.3.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v1.3.2 (2021-03-13)
- Change: improve best match selection
- Change: poster language fallback to highest rated
- Fix: handle errors when connecting to TMDB

v1.3.0 - v1.3.1
- Change: removed dependencies on requests, tmdbsimple, and trakt modules
- Change: simplify artwork selection options

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
