### PR TITLE
[metadata.tvshows.themoviedb.org.python] 1.4.4

### DIFF
--- a/metadata.tvshows.themoviedb.org.python/addon.xml
+++ b/metadata.tvshows.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.themoviedb.org.python"
   name="TMDb TV Shows"
-  version="1.4.3"
+  version="1.4.4"
   provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -9,8 +9,9 @@
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="00:15"/>
   <extension point="xbmc.addon.metadata">
-    <news>1.4.3
-fix for crash if episode group has a season with no episodes
+    <news>1.4.4
+fix so studios get added even if there is no country
+change the default setting so that studio and country are stored separately
 	</news>
     <summary lang="en_GB">Fetch TV Show metadata from themoviedb.org</summary>
     <description lang="en_GB">The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb's strong international focus and breadth of data is largely unmatched and something we're incredibly proud of. Put simply, we live and breathe community and that's precisely what makes us different.</description>

--- a/metadata.tvshows.themoviedb.org.python/changelog.txt
+++ b/metadata.tvshows.themoviedb.org.python/changelog.txt
@@ -1,3 +1,7 @@
+1.4.4
+fix so studios get added even if there is no country
+change the default setting so that studio and country are stored separately
+
 1.4.3
 fix for crash if episode group has a season with no episodes
 

--- a/metadata.tvshows.themoviedb.org.python/libs/data_utils.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/data_utils.py
@@ -247,10 +247,10 @@ def add_main_show_info(list_item, show_info, full_info=True):
             country = None
         if network and country and settings.STUDIOCOUNTRY:
             video['studio'] = '{0} ({1})'.format(network['name'], country)
-            video['country'] = country
-        elif network and country:
+        elif network:
             video['studio'] = network['name']
-            video['country'] = country           
+        if country:
+            video['country'] = country        
         content_ratings = show_info.get('content_ratings', {}).get('results', {})
         if content_ratings:
             mpaa = ''

--- a/metadata.tvshows.themoviedb.org.python/libs/settings.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/settings.py
@@ -75,7 +75,7 @@ source_settings = json.loads(source_params.get('pathSettings', '{}'))
 
 KEEPTITLE =source_settings.get('keeporiginaltitle', ADDON.getSettingBool('keeporiginaltitle'))
 CATLANDSCAPE = source_settings.get('cat_landscape', True)
-STUDIOCOUNTRY = source_settings.get('studio_country', True)
+STUDIOCOUNTRY = source_settings.get('studio_country', False)
 ENABTRAILER = source_settings.get('enab_trailer', ADDON.getSettingBool('enab_trailer'))
 PLAYERSOPT = source_settings.get('players_opt', ADDON.getSettingString('players_opt')).lower()
 VERBOSELOG =  source_settings.get('verboselog', ADDON.getSettingBool('verboselog'))


### PR DESCRIPTION
### Description
- fix so studios get added even if there is no country
- change the default setting so that studio and country are stored separately

<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
