### PR TITLE
[metadata.tvdb.com.python@matrix] 1.0.3

### DIFF
--- a/metadata.tvdb.com.python/addon.xml
+++ b/metadata.tvdb.com.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="metadata.tvdb.com.python" name="The TVDB (new)" version="1.0.2" provider-name="Team Kodi">
+<addon id="metadata.tvdb.com.python" name="The TVDB (new)" version="1.0.3" provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
     <import addon="xbmc.python" version="3.0.0" />

--- a/metadata.tvdb.com.python/resources/lib/series.py
+++ b/metadata.tvdb.com.python/resources/lib/series.py
@@ -23,7 +23,7 @@ def search_series(title, settings, year=None) -> None:
     log(f'Search results {search_results}')
 
     possible_matches = _match_by_year(
-        search_results, year, title) if year is not None and len(year) > 0 else _filter_exact_matches(search_results, title)
+        search_results, year, title) if year else _filter_exact_matches(search_results, title)
 
     search_results = possible_matches if len(
         possible_matches) > 0 else search_results
@@ -60,7 +60,7 @@ def _match_by_year(search_results: list, year: int, title: str) -> list:
         return exact_year_match
 
     nearest_year = _nearest(
-        [int(item['firstAired'][:4]) for item in search_results if 'firstAired' in item and item['firstAired'] is not None], int(year))
+        [int(item['firstAired'][:4]) for item in search_results if 'firstAired' in item and item['firstAired']], int(year))
     exact_match_nearest_year = tvdb.filter_by_year(
         _filter_exact_matches(search_results, title), nearest_year)
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The TVDB (new)
  - Add-on ID: metadata.tvdb.com.python
  - Version number: 1.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/xbmc/metadata.tvdb.com.python
  
TheTVDB.com is a TV Scraper. The site is a massive open database that can be modified by anybody and contains full meta data for many shows in different languages. All content and images on the site have been contributed by their users for users and have a high standard or quality. The database schema and website are open source under the GPL.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
