### PR TITLE
[metadata.tvmaze@matrix] 1.1.0+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.0.6+matrix.1"
+  version="1.1.0+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -22,9 +22,9 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.0.6:
-- Changed handling special episodes to match TVmaze website listings.
-- Fixed a crash on a corrupted cache file.
-- Improved crash logging.</news>
+    <news>1.1.0:
+- Added support for alternative episode orders.
+- Fixed caching of downloaded show info.
+- Country codes are no longer added to studio names.</news>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import json
 import sys
 
 import six
@@ -27,7 +28,7 @@ import xbmcplugin
 from six.moves import urllib_parse
 
 from . import tvmaze_api, data_service
-from .utils import logger
+from .utils import logger, get_episode_order
 
 try:
     from typing import Optional, Text, Union, ByteString  # pylint: disable=unused-import
@@ -38,14 +39,14 @@ HANDLE = int(sys.argv[1])  # type: int
 
 
 def find_show(title, year=None):
-    # type: (Union[Text, bytes], Optional[Text]) -> None
+    # type: (Union[Text, ByteString], Optional[Text]) -> None
     """Find a show by title"""
-    if not isinstance(title, six.text_type):
+    if isinstance(title, bytes):
         title = title.decode('utf-8')
     logger.debug('Searching for TV show {} ({})'.format(title, year))
     search_results = tvmaze_api.search_show(title)
     if year is not None:
-        search_result = tvmaze_api.filter_by_year(search_results, year)
+        search_result = data_service.filter_by_year(search_results, year)
         search_results = (search_result,) if search_result else ()
     for search_result in search_results:
         show_name = search_result['show']['name']
@@ -63,8 +64,8 @@ def find_show(title, year=None):
         )
 
 
-def get_show_id_from_nfo(nfo):
-    # type: (Text) -> None
+def get_show_id_from_nfo(nfo, episode_order):
+    # type: (Text, Text) -> None
     """
     Get show ID by NFO file contents
 
@@ -79,7 +80,7 @@ def get_show_id_from_nfo(nfo):
     parse_result = data_service.parse_nfo_url(nfo)
     if parse_result:
         if parse_result.provider == 'tvmaze':
-            show_info = tvmaze_api.load_show_info(parse_result.show_id)
+            show_info = tvmaze_api.load_show_info(parse_result.show_id, episode_order)
         else:
             show_info = tvmaze_api.load_show_info_by_external_id(
                 parse_result.provider,
@@ -97,11 +98,11 @@ def get_show_id_from_nfo(nfo):
             )
 
 
-def get_details(show_id):
-    # type: (Text) -> None
+def get_details(show_id, episode_order):
+    # type: (Text, Text) -> None
     """Get details about a specific show"""
     logger.debug('Getting details for show id {}'.format(show_id))
-    show_info = tvmaze_api.load_show_info(show_id)
+    show_info = tvmaze_api.load_show_info(show_id, episode_order)
     if show_info is not None:
         list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
         list_item = data_service.add_main_show_info(list_item, show_info)
@@ -110,9 +111,10 @@ def get_details(show_id):
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
-def get_episode_list(show_id):  # pylint: disable=missing-docstring
-    # type: (Text) -> None
-    logger.debug('Getting episode list for show id {}'.format(show_id))
+def get_episode_list(show_id, episode_order):  # pylint: disable=missing-docstring
+    # type: (Text, Text) -> None
+    logger.debug('Getting episode list for show id {}, order: {}'.format(
+        show_id, episode_order))
     if not show_id.isdigit():
         # Kodi has a bug: when a show directory contains an XML NFO file with
         # episodeguide URL, that URL is always passed here regardless of
@@ -121,17 +123,18 @@ def get_episode_list(show_id):  # pylint: disable=missing-docstring
         if not parse_result:
             return
         if parse_result.provider == 'tvmaze':
-            show_info = tvmaze_api.load_show_info(parse_result.show_id)
+            show_info = tvmaze_api.load_show_info(parse_result.show_id, episode_order)
         else:
             brief_show_info = tvmaze_api.load_show_info_by_external_id(
                 parse_result.provider,
                 parse_result.show_id
             )
-            show_info = tvmaze_api.load_show_info(brief_show_info['id'])
+            show_info = tvmaze_api.load_show_info(brief_show_info['id'], episode_order)
     else:
-        show_info = tvmaze_api.load_show_info(show_id)
+        show_info = tvmaze_api.load_show_info(show_id, episode_order)
     if show_info is not None:
-        for episode in six.itervalues(show_info['episodes']):
+        episode_list = show_info['episodes']
+        for episode in six.itervalues(episode_list):
             list_item = xbmcgui.ListItem(episode['name'], offscreen=True)
             list_item = data_service.add_episode_info(list_item, episode, full_info=False)
             encoded_ids = urllib_parse.urlencode(
@@ -148,14 +151,14 @@ def get_episode_list(show_id):  # pylint: disable=missing-docstring
             )
 
 
-def get_episode_details(encoded_ids):  # pylint: disable=missing-docstring
-    # type: (Text) -> None
+def get_episode_details(encoded_ids, episode_order):  # pylint: disable=missing-docstring
+    # type: (Text, Text) -> None
     encoded_ids = urllib_parse.unquote(encoded_ids)
     decoded_ids = dict(urllib_parse.parse_qsl(encoded_ids))
     logger.debug('Getting episode details for {}'.format(decoded_ids))
-    episode_info = tvmaze_api.load_episode_info(
-        decoded_ids['show_id'], decoded_ids['episode_id']
-    )
+    episode_info = tvmaze_api.load_episode_info(decoded_ids['show_id'],
+                                                decoded_ids['episode_id'],
+                                                episode_order)
     if episode_info:
         list_item = xbmcgui.ListItem(episode_info['name'], offscreen=True)
         list_item = data_service.add_episode_info(list_item, episode_info, full_info=True)
@@ -164,15 +167,15 @@ def get_episode_details(encoded_ids):  # pylint: disable=missing-docstring
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
-def get_artwork(show_id):
-    # type: (Text) -> None
+def get_artwork(show_id, episode_order):
+    # type: (Text, Text) -> None
     """
     Get available artwork for a show
 
     :param show_id: default unique ID set by setUniqueIDs() method
     """
     logger.debug('Getting artwork for show ID {}'.format(show_id))
-    show_info = tvmaze_api.load_show_info(show_id)
+    show_info = tvmaze_api.load_show_info(show_id, episode_order)
     if show_info is not None:
         list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
         list_item = data_service.set_show_artwork(show_info, list_item)
@@ -191,18 +194,20 @@ def router(paramstring):
     """
     params = dict(urllib_parse.parse_qsl(paramstring))
     logger.debug('Called addon with params: {}'.format(sys.argv))
+    path_settings = json.loads(params['pathSettings'])
+    episode_order = get_episode_order(path_settings)
     if params['action'] == 'find':
         find_show(params['title'], params.get('year'))
     elif params['action'].lower() == 'nfourl':
-        get_show_id_from_nfo(params['nfo'])
+        get_show_id_from_nfo(params['nfo'], episode_order)
     elif params['action'] == 'getdetails':
-        get_details(params['url'])
+        get_details(params['url'], episode_order)
     elif params['action'] == 'getepisodelist':
-        get_episode_list(params['url'])
+        get_episode_list(params['url'], episode_order)
     elif params['action'] == 'getepisodedetails':
-        get_episode_details(params['url'])
+        get_episode_details(params['url'], episode_order)
     elif params['action'] == 'getartwork':
-        get_artwork(params['id'])
+        get_artwork(params['id'], episode_order)
     else:
         raise RuntimeError('Invalid addon call: {}'.format(sys.argv))
     xbmcplugin.endOfDirectory(HANDLE)

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -31,6 +31,16 @@ except ImportError:
 ADDON_ID = 'metadata.tvmaze'
 ADDON = Addon()
 
+EPISODE_ORDER_MAP = {
+    0: 'default',
+    1: 'dvd_release',
+    2: 'verbatim_order',
+    3: 'country_premiere',
+    4: 'streaming_premiere',
+    5: 'broadcast_premiere',
+    6: 'language_premiere',
+}
+
 
 class logger:
     log_message_prefix = '[{} ({})]: '.format(ADDON_ID, ADDON.getAddonInfo('version'))
@@ -71,3 +81,12 @@ def safe_get(dct, key, default=None):
     if key in dct and dct[key] is not None:
         return dct[key]
     return default
+
+
+def get_episode_order(path_settings):
+    # type: (Dict[Text, Any]) -> Text
+    episode_order_enum = path_settings.get('episode_order')
+    if episode_order_enum is None:
+        episode_order_enum = int(ADDON.getSetting('episode_order'))
+    episode_order = EPISODE_ORDER_MAP.get(episode_order_enum, 'default')
+    return episode_order

--- a/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,44 @@
+# Kodi Media Center language file
+# Translators: put your translations in msgstr lines. Preserve items in curly {} and square [] brackets.
+msgid ""
+msgstr ""
+
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+msgctxt "#32001"
+msgid "Preferred Episode Order"
+msgstr ""
+
+msgctxt "#32002"
+msgid "Default"
+msgstr ""
+
+msgctxt "#32003"
+msgid "DVD/BluRay Release"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Verbatim"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Country Premiere"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Streaming Premiere"
+msgstr ""
+
+msgctxt "#32007"
+msgid "Broadcast Premiere"
+msgstr ""
+
+msgctxt "#32008"
+msgid "English Language Premiere"
+msgstr ""

--- a/metadata.tvmaze/resources/settings.xml
+++ b/metadata.tvmaze/resources/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <category label="32000">
+      <setting label="32001" type="enum" id="episode_order"
+               lvalues="32002|32003|32004|32005|32006|32007|32008"/>
+    </category>
+</settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.1.0+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.1.0:
- Added support for alternative episode orders.
- Fixed caching of downloaded show info.
- Country codes are no longer added to studio names.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
