### PR TITLE
[metadata.themoviedb.org.python@matrix] 1.3.3+matrix.1

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.3.2+matrix.1"
+       version="1.3.3+matrix.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,12 +11,11 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.3.2 (2021-03-13)
-- Change: improve best match selection
-- Change: poster language fallback to highest rated
-- Fix: handle errors when connecting to TMDB
+    <news>v1.3.3 (2021-05-16)
+- Fix: fix collection image fallback from TMDB
 
-v1.3.0 - v1.3.1
+v1.3.0 - v1.3.2
+- Change: improve best match selection
 - Change: removed dependencies on requests, tmdbsimple, and trakt modules
 - Change: simplify artwork selection options</news>
     <summary lang="af_ZA">TMDB Fliek Skraper</summary>

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+v1.3.3 (2021-05-16)
+- Fix: fix collection image fallback from TMDB
+
 v1.3.2 (2021-03-13)
 - Change: improve best match selection
 - Change: poster language fallback to highest rated

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
@@ -72,6 +72,8 @@ class TMDBMovieScraper(object):
             movie['belongs_to_collection'] else None
         collection_fallback = _get_moviecollection(movie['belongs_to_collection'].get('id')) if \
             movie['belongs_to_collection'] else None
+        if collection and collection_fallback and 'images' in collection_fallback:
+            collection['images'] = collection_fallback['images']
 
         return {'movie': movie, 'movie_fallback': movie_fallback, 'collection': collection,
             'collection_fallback': collection_fallback}

--- a/metadata.themoviedb.org.python/resources/language/resource.language.zh_cn/strings.po
+++ b/metadata.themoviedb.org.python/resources/language/resource.language.zh_cn/strings.po
@@ -17,8 +17,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#30000"
-msgid "Enable Fanart"
-msgstr "启用同人画"
+msgid "Enable fanart from TMDb"
+msgstr "启用 TMDb 同人画"
 
 msgctxt "#30001"
 msgid "Prefer Trailer from HD-Trailers.net"
@@ -29,8 +29,8 @@ msgid "Preferred Language"
 msgstr "首选语言"
 
 msgctxt "#30003"
-msgid "Get Rating from"
-msgstr "获取评分于"
+msgid "Default Rating from"
+msgstr "默认评分获取于"
 
 msgctxt "#30004"
 msgid "Enable Trailer (YouTube)"
@@ -43,3 +43,39 @@ msgstr "使用未翻译片名"
 msgctxt "#30006"
 msgid "Preferred Certification Country"
 msgstr "首选电影分级国别"
+
+msgctxt "#30007"
+msgid "Add also IMDb ratings"
+msgstr "同时获取 IMDb 评分"
+
+msgctxt "#30008"
+msgid "Certification Prefix"
+msgstr "证书前缀"
+
+msgctxt "#30009"
+msgid "Add multiple studios"
+msgstr "获取多个制片公司"
+
+msgctxt "#30010"
+msgid "Add also Trakt.tv ratings"
+msgstr "同时获取 Trakt.tv 评分"
+
+msgctxt "#30011"
+msgid "Add keywords as tags"
+msgstr "关键字添加为标签"
+
+msgctxt "#30012"
+msgid "Separate TMDb fanart with title to landscape"
+msgstr "将含片名的 TMDb 同人画归入场景贴画"
+
+msgctxt "#30100"
+msgid "Language for Fanart.tv artwork"
+msgstr "Fanart.tv 艺术图片的语言"
+
+msgctxt "#30101"
+msgid "Fanart.tv personal API key (optional)"
+msgstr "Fanart.tv 个人 API 密钥（可选）"
+
+msgctxt "#30102"
+msgid "Enable artwork from Fanart.tv"
+msgstr "启用 Fanart.tv 艺术图片"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 1.3.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v1.3.3 (2021-05-16)
- Fix: fix collection image fallback from TMDB

v1.3.0 - v1.3.2
- Change: improve best match selection
- Change: removed dependencies on requests, tmdbsimple, and trakt modules
- Change: simplify artwork selection options

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
