### PR TITLE
[metadata.tvmaze@matrix] 1.1.1+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.1.0+matrix.1"
+  version="1.1.1+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -9,7 +9,7 @@
     <import addon="script.module.six" />
     <import addon="script.module.requests" />
   </requires>
-  <extension point="xbmc.metadata.scraper.tvshows" library="main.py"/>
+  <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="48:00"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Fetch TV Show metadata from TVmaze.com</summary>
     <description lang="en_GB">TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
@@ -22,7 +22,12 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.1.0:
+    <news>1.1.1:
+- Fixed scraping some alternative episode orders.
+- Fixed compatibility with Kodi 20 "N".
+- Reworked caching mechanism.
+
+1.1.0:
 - Added support for alternative episode orders.
 - Fixed caching of downloaded show info.
 - Country codes are no longer added to studio names.</news>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -64,8 +64,8 @@ def find_show(title, year=None):
         )
 
 
-def get_show_id_from_nfo(nfo, episode_order):
-    # type: (Text, Text) -> None
+def get_show_id_from_nfo(nfo):
+    # type: (Text) -> None
     """
     Get show ID by NFO file contents
 
@@ -80,7 +80,7 @@ def get_show_id_from_nfo(nfo, episode_order):
     parse_result = data_service.parse_nfo_url(nfo)
     if parse_result:
         if parse_result.provider == 'tvmaze':
-            show_info = tvmaze_api.load_show_info(parse_result.show_id, episode_order)
+            show_info = tvmaze_api.load_show_info(parse_result.show_id)
         else:
             show_info = tvmaze_api.load_show_info_by_external_id(
                 parse_result.provider,
@@ -98,11 +98,11 @@ def get_show_id_from_nfo(nfo, episode_order):
             )
 
 
-def get_details(show_id, episode_order):
-    # type: (Text, Text) -> None
+def get_details(show_id):
+    # type: (Text) -> None
     """Get details about a specific show"""
     logger.debug('Getting details for show id {}'.format(show_id))
-    show_info = tvmaze_api.load_show_info(show_id, episode_order)
+    show_info = tvmaze_api.load_show_info(show_id)
     if show_info is not None:
         list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
         list_item = data_service.add_main_show_info(list_item, show_info)
@@ -123,23 +123,25 @@ def get_episode_list(show_id, episode_order):  # pylint: disable=missing-docstri
         if not parse_result:
             return
         if parse_result.provider == 'tvmaze':
-            show_info = tvmaze_api.load_show_info(parse_result.show_id, episode_order)
+            show_info = tvmaze_api.load_show_info(parse_result.show_id)
         else:
-            brief_show_info = tvmaze_api.load_show_info_by_external_id(
+            show_info = tvmaze_api.load_show_info_by_external_id(
                 parse_result.provider,
                 parse_result.show_id
             )
-            show_info = tvmaze_api.load_show_info(brief_show_info['id'], episode_order)
-    else:
-        show_info = tvmaze_api.load_show_info(show_id, episode_order)
-    if show_info is not None:
-        episode_list = show_info['episodes']
-        for episode in six.itervalues(episode_list):
+        if show_info:
+            show_id = str(show_info['id'])
+    if show_id.isdigit():
+        episodes_map = tvmaze_api.load_episodes_map(show_id, episode_order)
+        for episode in six.itervalues(episodes_map):
             list_item = xbmcgui.ListItem(episode['name'], offscreen=True)
             list_item = data_service.add_episode_info(list_item, episode, full_info=False)
-            encoded_ids = urllib_parse.urlencode(
-                {'show_id': str(show_info['id']), 'episode_id': str(episode['id'])}
-            )
+            encoded_ids = urllib_parse.urlencode({
+                'show_id': show_id,
+                'episode_id': str(episode['id']),
+                'season': str(episode['season']),
+                'episode': str(episode['number']),
+            })
             # Below "url" is some unique ID string (may be an actual URL to an episode page)
             # that allows to retrieve information about a specific episode.
             url = urllib_parse.quote(encoded_ids)
@@ -158,6 +160,8 @@ def get_episode_details(encoded_ids, episode_order):  # pylint: disable=missing-
     logger.debug('Getting episode details for {}'.format(decoded_ids))
     episode_info = tvmaze_api.load_episode_info(decoded_ids['show_id'],
                                                 decoded_ids['episode_id'],
+                                                decoded_ids['season'],
+                                                decoded_ids['episode'],
                                                 episode_order)
     if episode_info:
         list_item = xbmcgui.ListItem(episode_info['name'], offscreen=True)
@@ -167,15 +171,15 @@ def get_episode_details(encoded_ids, episode_order):  # pylint: disable=missing-
         xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem(offscreen=True))
 
 
-def get_artwork(show_id, episode_order):
-    # type: (Text, Text) -> None
+def get_artwork(show_id):
+    # type: (Text) -> None
     """
     Get available artwork for a show
 
     :param show_id: default unique ID set by setUniqueIDs() method
     """
     logger.debug('Getting artwork for show ID {}'.format(show_id))
-    show_info = tvmaze_api.load_show_info(show_id, episode_order)
+    show_info = tvmaze_api.load_show_info(show_id)
     if show_info is not None:
         list_item = xbmcgui.ListItem(show_info['name'], offscreen=True)
         list_item = data_service.set_show_artwork(show_info, list_item)
@@ -199,15 +203,15 @@ def router(paramstring):
     if params['action'] == 'find':
         find_show(params['title'], params.get('year'))
     elif params['action'].lower() == 'nfourl':
-        get_show_id_from_nfo(params['nfo'], episode_order)
+        get_show_id_from_nfo(params['nfo'])
     elif params['action'] == 'getdetails':
-        get_details(params['url'], episode_order)
+        get_details(params['url'])
     elif params['action'] == 'getepisodelist':
         get_episode_list(params['url'], episode_order)
     elif params['action'] == 'getepisodedetails':
         get_episode_details(params['url'], episode_order)
     elif params['action'] == 'getartwork':
-        get_artwork(params['id'], episode_order)
+        get_artwork(params['id'])
     else:
         raise RuntimeError('Invalid addon call: {}'.format(sys.argv))
     xbmcplugin.endOfDirectory(HANDLE)

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -28,8 +28,8 @@ try:
 except ImportError:
     pass
 
-ADDON_ID = 'metadata.tvmaze'
 ADDON = Addon()
+ADDON_ID = ADDON.getAddonInfo('id')
 
 EPISODE_ORDER_MAP = {
     0: 'default',


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.1.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.1.1:
- Fixed scraping some alternative episode orders.
- Fixed compatibility with Kodi 20 "N".
- Reworked caching mechanism.

1.1.0:
- Added support for alternative episode orders.
- Fixed caching of downloaded show info.
- Country codes are no longer added to studio names.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
