### PR TITLE
[leia] Add language workflows

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,0 +1,54 @@
+name: Increment version of updated languages
+
+on:
+  push:
+    branches: [ leia ]
+    paths:
+      - '**metadata.album.universal**resource.language.**strings.po'
+      - '**metadata.artists.universal**resource.language.**strings.po'
+      - '**metadata.universal**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'xbmc/repo-scrapers'
+    runs-on: ubuntu-latest
+    name: Increment version of updated languages
+
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ${{ github.event.repository.name }}
+
+      - name: Checkout Scripts
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: xbmc/weblate-supplementary-scripts
+          path: scripts
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Get changed files
+        uses: trilom/file-changes-action@v1.2.4
+
+      - name: Increment version of updated languages
+        run: |
+          python3 ../scripts/repo-resources/increment_version.py $HOME/files.json
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Create PR for incremented versions
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Language add-on versions incremented
+          title: Language add-on versions incremented
+          body: Language add-on versions incrementing triggered by ${{ github.sha }}
+          branch: inc-ver
+          delete-branch: true
+          path: ./${{ github.event.repository.name }}
+          reviewers: gade01

--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -1,0 +1,58 @@
+name: Sync addon metadata translations
+
+on:
+  push:
+    branches: [ leia ]
+    paths:
+      - '**metadata.album.universal**addon.xml'
+      - '**metadata.album.universal**resource.language.**strings.po'
+      - '**metadata.artists.universal**addon.xml'
+      - '**metadata.artists.universal**resource.language.**strings.po'
+      - '**metadata.universal**addon.xml'
+      - '**metadata.universal**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'xbmc/repo-scrapers'
+    runs-on: ubuntu-latest
+
+    strategy:
+
+      fail-fast: false
+      matrix:
+        python-version: [ 3.9 ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: project
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/xbmc/sync_addon_metadata_translations.git
+
+      - name: Run sync-addon-metadata-translations
+        run: |
+          sync-addon-metadata-translations --path ./metadata.album.universal/
+          sync-addon-metadata-translations --path ./metadata.artists.universal/
+          sync-addon-metadata-translations --path ./metadata.universal/
+        working-directory: ./project
+
+      - name: Create PR for sync-addon-metadata-translations changes
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Sync of addon metadata translations
+          title: Sync of addon metadata translations
+          body: Sync of addon metadata translations triggered by ${{ github.sha }}
+          branch: amt-sync
+          delete-branch: true
+          path: ./project
+          reviewers: gade01


### PR DESCRIPTION
### Description
This will add two workflows:
- Workflow to sync metadata (`summary`, `description` and `disclaimer`) between addon.xml and language files.
This workflow will run on changes in addon.xml or language files and create a PR with the synced changes.
- Workflow to increase version number in addon.xml
This workflow will run on changes in language files and create a PR with the version bump.

The workflows will only run in leia branch and for these addons:
- metadata.album.universal
- metadata.artists.universal
- metadata.universal
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0