### PR TITLE
[metadata.tvmaze@leia] 1.1.2

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.1.1"
+  version="1.2.0"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -9,7 +9,7 @@
     <import addon="script.module.six" />
     <import addon="script.module.requests" />
   </requires>
-  <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="48:00"/>
+  <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="24:00"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Fetch TV Show metadata from TVmaze.com</summary>
     <description lang="en_GB">TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
@@ -22,14 +22,8 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.1.1:
-- Fixed scraping some alternative episode orders.
-- Fixed compatibility with Kodi 20 "N".
-- Reworked caching mechanism.
-
-1.1.0:
-- Added support for alternative episode orders.
-- Fixed caching of downloaded show info.
-- Country codes are no longer added to studio names.</news>
+    <news>1.2.0:
+- Added IMDB ratings.</news>
+    <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/imdb_rating.py
+++ b/metadata.tvmaze/libs/imdb_rating.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+
+import json
+import re
+
+import requests
+
+from .utils import logger
+
+try:
+    from typing import Text, Dict, Union, Optional  # pylint: disable=unused-import
+except ImportError:
+    pass
+
+IMDB_TITLE_URL = 'https://www.imdb.com/title/{}/'
+
+
+def get_imdb_rating(imdb_id):
+    # type: (Text) -> Optional[Dict[Text, Union[int, float]]]
+    url = IMDB_TITLE_URL.format(imdb_id)
+    response = requests.get(url)
+    if response.ok:
+        ld_json_match = re.search(r'<script type="application/ld\+json">([^<]+?)</script>',
+                                  response.text)
+        if ld_json_match is not None:
+            ld_json = json.loads(ld_json_match.group(1))
+            aggregate_rating = ld_json.get('aggregateRating')
+            if aggregate_rating:
+                rating = aggregate_rating['ratingValue']
+                votes = aggregate_rating['ratingCount']
+                return {'rating': rating, 'votes': votes}
+    logger.debug('Unable to get IMDB rating for ID {}. Status: {}, response: {}'.format(
+        imdb_id, response.status_code, response.text))
+    return None

--- a/metadata.tvmaze/libs/tvmaze_api.py
+++ b/metadata.tvmaze/libs/tvmaze_api.py
@@ -26,7 +26,8 @@ from requests.exceptions import HTTPError
 
 from . import cache_service as cache
 from .data_service import process_episode_list
-from .utils import logger
+from .imdb_rating import get_imdb_rating
+from .utils import logger, safe_get
 
 try:
     from typing import Text, Optional, Union, List, Dict, Any  # pylint: disable=unused-import
@@ -104,6 +105,12 @@ def load_show_info(show_id):
         if isinstance(show_info['_embedded']['images'], list):
             show_info['_embedded']['images'].sort(key=lambda img: img['main'],
                                                   reverse=True)
+        external_ids = safe_get(show_info, 'externals', {})
+        imdb_id = external_ids.get('imdb')
+        if imdb_id is not None:
+            show_info['imdb_rating'] = get_imdb_rating(imdb_id)
+        else:
+            show_info['imdb_rating'] = None
         cache.cache_show_info(show_info)
     return show_info
 

--- a/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
@@ -42,3 +42,7 @@ msgstr ""
 msgctxt "#32008"
 msgid "English Language Premiere"
 msgstr ""
+
+msgctxt "#32009"
+msgid "Default Rating"
+msgstr ""

--- a/metadata.tvmaze/resources/settings.xml
+++ b/metadata.tvmaze/resources/settings.xml
@@ -3,5 +3,7 @@
     <category label="32000">
       <setting label="32001" type="enum" id="episode_order"
                lvalues="32002|32003|32004|32005|32006|32007|32008"/>
+      <setting label="32009" type="labelenum" id="default_rating"
+               values="TVmaze|IMDB"/>
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.1.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.1.2:
- Performance optimization.

1.1.1:
- Fixed scraping some alternative episode orders.
- Fixed compatibility with Kodi 20 "N".
- Reworked caching mechanism.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
