### PR TITLE
[metadata.tvmaze@matrix] 1.1.2+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.1.1+matrix.1"
+  version="1.1.2+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -22,14 +22,13 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.1.1:
+    <news>1.1.2:
+- Performance optimization.
+
+1.1.1:
 - Fixed scraping some alternative episode orders.
 - Fixed compatibility with Kodi 20 "N".
-- Reworked caching mechanism.
-
-1.1.0:
-- Added support for alternative episode orders.
-- Fixed caching of downloaded show info.
-- Country codes are no longer added to studio names.</news>
+- Reworked caching mechanism.</news>
+    <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.1.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.1.2:
- Performance optimization.

1.1.1:
- Fixed scraping some alternative episode orders.
- Fixed compatibility with Kodi 20 "N".
- Reworked caching mechanism.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
