### PR TITLE
[metadata.themoviedb.org.python] v1.4.3

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.4.2"
+       version="1.4.3"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -12,6 +12,9 @@
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
     <news>
+	v1.4.3 (2021-10-15)
+- Change: Refactoring and optimization
+	
 	v1.4.2 (2021-10-02)
 - Feature: downloading logos from tmdb
 - Feature: search language option added

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+v1.4.3 (2021-10-15)
+- Fix: Refactoring and optimization
+
 v1.4.2 (2021-10-02)
 - Feature: downloading logos from tmdb
 - Feature: search language option added

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
@@ -1,14 +1,12 @@
 from datetime import datetime, timedelta
 from . import tmdbapi
-import xbmc
-
 
 class TMDBMovieScraper(object):
-    def __init__(self, url_settings, language, search_language, certification_country):
+    def __init__(self, url_settings, language, certification_country, search_language='en'):
         self.url_settings = url_settings
         self.language = language
-        self.search_language = search_language
         self.certification_country = certification_country
+        self.search_language = search_language
         self._urls = None
 
     @property
@@ -164,11 +162,7 @@ def _parse_artwork(movie, collection, urlbases, language):
     if 'images' in movie:
         posters = _get_images_with_fallback(movie['images']['posters'], urlbases, language)
         landscape = _get_images(movie['images']['backdrops'], urlbases, language)
-        logos = _get_images(movie['images']['logos'], urlbases, language)
-        if not logos:
-            logos = _get_images(movie['images']['logos'], urlbases, None)
-        if not logos:
-            logos = _get_images(movie['images']['logos'], urlbases, "en")
+        logos = _get_images_with_fallback(movie['images']['logos'], urlbases, language)
         fanart = _get_images(movie['images']['backdrops'], urlbases, None)
 
     setposters = []

--- a/metadata.themoviedb.org.python/python/scraper.py
+++ b/metadata.themoviedb.org.python/python/scraper.py
@@ -24,21 +24,21 @@ def get_tmdb_scraper(settings):
     language = settings.getSettingString('language')
     certcountry = settings.getSettingString('tmdbcertcountry')
     search_language = settings.getSettingString('searchlanguage')
-    return TMDBMovieScraper(ADDON_SETTINGS, language, search_language, certcountry)
+    return TMDBMovieScraper(ADDON_SETTINGS, language, certcountry, search_language)
 
 def search_for_movie(title, year, handle, settings):
     log("Find movie with title '{title}' from year '{year}'".format(title=title, year=year), xbmc.LOGINFO)
     title = _strip_trailing_article(title)
-    search_results = get_tmdb_scraper(settings).search(title, year)
+    scraper = get_tmdb_scraper(settings)
 
+    if year is not None:
+        search_results = scraper.search(title, year)
+        if not search_results:
+            search_results = scraper.search(title,str(int(year)-1))
+        if not search_results:
+            search_results = scraper.search(title,str(int(year)+1))
     if not search_results:
-        if year is not None:
-            search_results = get_tmdb_scraper(settings).search(title,str(int(year)-1))
-    if not search_results:
-        if year is not None:
-            search_results = get_tmdb_scraper(settings).search(title,str(int(year)+1))
-    if not search_results:
-        search_results = get_tmdb_scraper(settings).search(title)
+        search_results = scraper.search(title)
     if not search_results:
         return
     if 'error' in search_results:


### PR DESCRIPTION
### Description
Small optimizations for [metadata.themoviedb.org.python].
Possible fix for https://github.com/croneter/PlexKodiConnect/issues/1657 by setting default search_language.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.