### PR TITLE
[metadata.themoviedb.org.python@matrix] 1.5.1+matrix.1

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.5.0+matrix.1"
+       version="1.5.1+matrix.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,7 +11,10 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.5.0 (2021-10-16)
+    <news>v1.5.1 (2021-10-19)
+- Fix: search error when no year
+
+v1.5.0 (2021-10-16)
 - Feature: downloading logos from tmdb
 - Feature: search language option added
 - Change: searching movies from different years if not found

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+v1.5.1 (2021-10-19)
+- Fix: search error when no year
+
 v1.5.0 (2021-10-16)
 - Feature: downloading logos from tmdb
 - Feature: search language option added

--- a/metadata.themoviedb.org.python/python/scraper.py
+++ b/metadata.themoviedb.org.python/python/scraper.py
@@ -31,16 +31,17 @@ def search_for_movie(title, year, handle, settings):
     title = _strip_trailing_article(title)
     scraper = get_tmdb_scraper(settings)
 
+    search_results = scraper.search(title, year)
     if year is not None:
-        search_results = scraper.search(title, year)
         if not search_results:
             search_results = scraper.search(title,str(int(year)-1))
         if not search_results:
             search_results = scraper.search(title,str(int(year)+1))
-    if not search_results:
-        search_results = scraper.search(title)
+        if not search_results:
+            search_results = scraper.search(title)
     if not search_results:
         return
+
     if 'error' in search_results:
         header = "The Movie Database Python error searching with web service TMDB"
         xbmcgui.Dialog().notification(header, search_results['error'], xbmcgui.NOTIFICATION_WARNING)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 1.5.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v1.5.1 (2021-10-19)
- Fix: search error when no year

v1.5.0 (2021-10-16)
- Feature: downloading logos from tmdb
- Feature: search language option added
- Change: searching movies from different years if not found
- Fix: don't error when all fanart disabled
- Fix: don't try to fetch movie set artwork from Fanart.TV if movie is not part of set

v1.4.0 (2021-07-10)
- Feature: update to new IMDB page layout
- Feature: update language files and translation system

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
