### PR TITLE
[metadata.tvmaze@leia] 1.2.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.2.0"
+  version="1.2.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -22,7 +22,11 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.2.0:
+    <news>1.2.1:
+- Added parsing of uniqueid NFO tag.
+- Limit the number of saved artwork.
+
+1.2.0:
 - Added IMDB ratings.</news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>

--- a/metadata.tvmaze/libs/tvmaze_api.py
+++ b/metadata.tvmaze/libs/tvmaze_api.py
@@ -27,7 +27,7 @@ from requests.exceptions import HTTPError
 from . import cache_service as cache
 from .data_service import process_episode_list
 from .imdb_rating import get_imdb_rating
-from .utils import logger, safe_get
+from .utils import logger
 
 try:
     from typing import Text, Optional, Union, List, Dict, Any  # pylint: disable=unused-import
@@ -44,7 +44,7 @@ ALTERNATE_LISTS_URL = 'http://api.tvmaze.com/shows/{}/alternatelists'
 ALTERNATE_EPISODES_URL = 'http://api.tvmaze.com/alternatelists/{}/alternateepisodes'
 
 HEADERS = (
-    ('User-Agent', 'Kodi scraper for tvmaze.com by Roman V.M.; roman1972@gmail.com'),
+    ('User-Agent', 'Kodi scraper for tvmaze.com by Roman V.M.'),
     ('Accept', 'application/json'),
 )
 SESSION = requests.Session()
@@ -105,7 +105,7 @@ def load_show_info(show_id):
         if isinstance(show_info['_embedded']['images'], list):
             show_info['_embedded']['images'].sort(key=lambda img: img['main'],
                                                   reverse=True)
-        external_ids = safe_get(show_info, 'externals', {})
+        external_ids = show_info.get('externals') or {}
         imdb_id = external_ids.get('imdb')
         if imdb_id is not None:
             show_info['imdb_rating'] = get_imdb_rating(imdb_id)

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -71,18 +71,6 @@ class logger:
         logger.log(message, xbmc.LOGDEBUG)
 
 
-def safe_get(dct, key, default=None):
-    # type: (Dict[Text, Any], Text, Any) -> Any
-    """
-    Get a key from dict
-
-    Returns the respective value or default if key is missing or the value is None.
-    """
-    if key in dct and dct[key] is not None:
-        return dct[key]
-    return default
-
-
 def get_episode_order(path_settings):
     # type: (Dict[Text, Any]) -> Text
     episode_order_enum = path_settings.get('episode_order')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.2.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.2.1:
- Added parsing of uniqueid NFO tag.
- Limit the number of saved artwork.

1.2.0:
- Added IMDB ratings.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
