### PR TITLE
[metadata.tvmaze@leia] 1.2.2

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.2.1"
+  version="1.2.2"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -22,12 +22,12 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.2.1:
-- Added parsing of uniqueid NFO tag.
-- Limit the number of saved artwork.
+    <news>1.2.2:
+- Improved parsing of NFO files.
 
-1.2.0:
-- Added IMDB ratings.</news>
-    <reuselanguageinvoker>true</reuselanguageinvoker>
+1.2.1:
+- Added parsing of uniqueid NFO tag.
+- Limit the number of saved artwork.</news>
+    <reuselanguageinvoker>false</reuselanguageinvoker>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/tvmaze_api.py
+++ b/metadata.tvmaze/libs/tvmaze_api.py
@@ -187,7 +187,7 @@ def load_episodes_map(show_id, episode_order):
         if episode_list:
             processed_episodes = process_episode_list(episode_list)
             cache.cache_episodes_map(show_id, processed_episodes)
-    return processed_episodes
+    return processed_episodes or {}
 
 
 def load_episode_info(show_id, episode_id, season, episode, episode_order):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.2.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.2.2:
- Improved parsing of NFO files.

1.2.1:
- Added parsing of uniqueid NFO tag.
- Limit the number of saved artwork.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
