### PR TITLE
[metadata.tvmaze@matrix] 1.2.3+matrix.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.2.2+matrix.1"
+  version="1.2.3+matrix.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -22,12 +22,11 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.2.2:
-- Improved parsing of NFO files.
+    <news>1.2.3:
+- Fixed a crash because of a circular import.
 
-1.2.1:
-- Added parsing of uniqueid NFO tag.
-- Limit the number of saved artwork.</news>
+1.2.2:
+- Improved parsing of NFO files.</news>
     <reuselanguageinvoker>false</reuselanguageinvoker>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -138,7 +138,7 @@ def get_episode_list(show_id, episode_order):  # pylint: disable=missing-docstri
         if show_info:
             show_id = str(show_info['id'])
     if show_id.isdigit():
-        episodes_map = tvmaze_api.load_episodes_map(show_id, episode_order)
+        episodes_map = data_service.get_episodes_map(show_id, episode_order)
         for episode in six.itervalues(episodes_map):
             list_item = xbmcgui.ListItem(episode['name'], offscreen=True)
             list_item = data_service.add_episode_info(list_item, episode, full_info=False)
@@ -164,11 +164,11 @@ def get_episode_details(encoded_ids, episode_order):  # pylint: disable=missing-
     encoded_ids = urllib_parse.unquote(encoded_ids)
     decoded_ids = dict(urllib_parse.parse_qsl(encoded_ids))
     logger.debug('Getting episode details for {}'.format(decoded_ids))
-    episode_info = tvmaze_api.load_episode_info(decoded_ids['show_id'],
-                                                decoded_ids['episode_id'],
-                                                decoded_ids['season'],
-                                                decoded_ids['episode'],
-                                                episode_order)
+    episode_info = data_service.get_episode_info(decoded_ids['show_id'],
+                                                 decoded_ids['episode_id'],
+                                                 decoded_ids['season'],
+                                                 decoded_ids['episode'],
+                                                 episode_order)
     if episode_info:
         list_item = xbmcgui.ListItem(episode_info['name'], offscreen=True)
         list_item = data_service.add_episode_info(list_item, episode_info, full_info=True)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.2.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.2.3:
- Fixed a crash because of a circular import.

1.2.2:
- Improved parsing of NFO files.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
