### PR TITLE
[metadata.tvmaze@matrix] 1.3.0

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.2.3+matrix.1"
+  version="1.3.0"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="xbmc.metadata" version="2.1.0"/>
-    <import addon="script.module.six" />
-    <import addon="script.module.requests" />
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="24:00"/>
   <extension point="xbmc.addon.metadata">
@@ -22,11 +20,10 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.2.3:
-- Fixed a crash because of a circular import.
+    <news>1.3.0:
 
-1.2.2:
-- Improved parsing of NFO files.</news>
+- Improved parsing of NFO files.
+- Completely removed Python 2 support.</news>
     <reuselanguageinvoker>false</reuselanguageinvoker>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/data_service.py
+++ b/metadata.tvmaze/libs/data_service.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-#
 # Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -17,34 +15,28 @@
 
 """Functions to process data"""
 
-from __future__ import absolute_import, unicode_literals
-
 import re
-from collections import namedtuple, defaultdict
+from collections import defaultdict
+from typing import Optional, Dict, List, Any, Sequence, NamedTuple
+try:
+    from xml.etree import cElementTree as Etree
+except ImportError:
+    from xml.etree import ElementTree as Etree
 
-import six
+from xbmcgui import ListItem
 
 from . import tvmaze_api, cache_service as cache
 from .utils import logger
 
-try:
-    from typing import Optional, Text, Dict, List, Any, Tuple  # pylint: disable=unused-import
-    from xbmcgui import ListItem  # pylint: disable=unused-import
-    InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
-except ImportError:
-    pass
+InfoType = Dict[str, Any]  # pylint: disable=invalid-name
 
 TAG_RE = re.compile(r'<[^>]+>')
 SHOW_ID_REGEXPS = (
-    re.compile(r'(tvmaze)\.com/shows/(\d+)/[\w\-]', re.I),
-    re.compile(r'(thetvdb)\.com/.*?series/(\d+)', re.I),
-    re.compile(r'(thetvdb)\.com[\w=&\?/]+id=(\d+)', re.I),
-    re.compile(r'(imdb)\.com/[\w/\-]+/(tt\d+)', re.I),
-    re.compile(r'<uniqueid.+?type="(tvdb|imdb)".*?>([t\d]+?)</uniqueid>', re.I | re.DOTALL),
+    r'(tvmaze)\.com/shows/(\d+)/[\w\-]',
+    r'(thetvdb)\.com/.*?series/(\d+)',
+    r'(thetvdb)\.com[\w=&\?/]+id=(\d+)',
+    r'(imdb)\.com/[\w/\-]+/(tt\d+)',
 )
-TITLE_RE = re.compile(r'<title>([^<]+?)</title>', re.I)
-YEAR_RE = re.compile(r'<year>(\d+?)</year>', re.I)
-PREMIERED_RE = re.compile(r'<premiered>([^<]+?)</premiered>', re.I)
 SUPPORTED_ARTWORK_TYPES = ('poster', 'banner')
 IMAGE_SIZES = ('large', 'original', 'medium')
 MAX_ARTWORK_NUMBER = 10
@@ -56,11 +48,19 @@ CLEAN_PLOT_REPLACEMENTS = (
     ('</p><p>', '[CR]'),
 )
 
-UrlParseResult = namedtuple('UrlParseResult', ['provider', 'show_id'])
+
+class UrlParseResult(NamedTuple):
+    provider: str
+    show_id: str
 
 
-def _process_episode_list(episode_list):
-    # type: (List[InfoType]) -> Dict[Text, InfoType]
+class XmlParseResult(NamedTuple):
+    title: str
+    year: str
+    uniqueids: Dict[str, str]
+
+
+def _process_episode_list(episode_list: List[InfoType]) -> Dict[str, InfoType]:
     """Convert embedded episode list to a dict"""
     processed_episodes = {}
     specials_list = []
@@ -70,7 +70,7 @@ def _process_episode_list(episode_list):
         if episode['number'] is not None or episode.get('type') == 'significant_special':
             # In some orders episodes with the same ID may occur more than once,
             # so we need a unique key.
-            key = '{}_{}_{}'.format(episode['id'], episode['season'], episode['number'])
+            key = f'{episode["id"]}_{episode["season"]}_{episode["number"]}'
             processed_episodes[key] = episode
         else:
             specials_list.append(episode)
@@ -78,13 +78,12 @@ def _process_episode_list(episode_list):
     for ep_number, special in enumerate(specials_list, 1):
         special['season'] = 0
         special['number'] = ep_number
-        key = '{}_{}_{}'.format(special['id'], special['season'], special['number'])
+        key = f'{special["id"]}_{special["season"]}_{special["number"]}'
         processed_episodes[key] = special
     return processed_episodes
 
 
-def get_episodes_map(show_id, episode_order):
-    # type: (Text, Text) -> Optional[Dict[Text, InfoType]]
+def get_episodes_map(show_id: str, episode_order: str) -> Optional[Dict[str, InfoType]]:
     processed_episodes = cache.load_episodes_map_from_cache(show_id)
     if not processed_episodes:
         episode_list = tvmaze_api.load_episode_list(show_id, episode_order)
@@ -94,8 +93,11 @@ def get_episodes_map(show_id, episode_order):
     return processed_episodes or {}
 
 
-def get_episode_info(show_id, episode_id, season, episode, episode_order):
-    # type: (Text, Text, Text, Text, Text) -> Optional[InfoType]
+def get_episode_info(show_id: str,
+                     episode_id: str,
+                     season: str,
+                     episode: str,
+                     episode_order: str) -> Optional[InfoType]:
     """
     Load episode info
 
@@ -110,17 +112,16 @@ def get_episode_info(show_id, episode_id, season, episode, episode_order):
     episodes_map = get_episodes_map(show_id, episode_order)
     if episodes_map is not None:
         try:
-            key = '{}_{}_{}'.format(episode_id, season, episode)
+            key = f'{episode_id}_{season}_{episode}'
             episode_info = episodes_map[key]
         except KeyError as exc:
-            logger.error('Unable to retrieve episode info: {}'.format(exc))
+            logger.error(f'Unable to retrieve episode info: {exc}')
     if episode_info is None:
         episode_info = tvmaze_api.load_episode_info(episode_id)
     return episode_info
 
 
-def _clean_plot(plot):
-    # type: (Text) -> Text
+def _clean_plot(plot: str) -> str:
     """Replace HTML tags with Kodi skin tags"""
     for repl in CLEAN_PLOT_REPLACEMENTS:
         plot = plot.replace(repl[0], repl[1])
@@ -128,8 +129,7 @@ def _clean_plot(plot):
     return plot
 
 
-def _set_cast(show_info, list_item):
-    # type: (InfoType, ListItem) -> ListItem
+def _set_cast(show_info: InfoType, list_item: ListItem) -> ListItem:
     """Extract cast from show info dict"""
     cast = []
     for index, item in enumerate(show_info['_embedded']['cast'], 1):
@@ -150,8 +150,7 @@ def _set_cast(show_info, list_item):
     return list_item
 
 
-def _get_credits(show_info):
-    # type: (InfoType) -> List[Text]
+def _get_credits(show_info: InfoType) -> List[str]:
     """Extract show creator(s) from show info"""
     credits_ = []
     for item in show_info['_embedded']['crew']:
@@ -160,11 +159,11 @@ def _get_credits(show_info):
     return credits_
 
 
-def _set_unique_ids(show_info, list_item):
-    # type: (InfoType, ListItem) -> ListItem
+def _set_unique_ids(show_info: InfoType, list_item: ListItem) -> ListItem:
     """Extract unique ID in various online databases"""
     unique_ids = {'tvmaze': str(show_info['id'])}
-    for key, value in six.iteritems(show_info.get('externals') or {}):
+    externals = show_info.get('externals') or {}
+    for key, value in externals.items():
         if key == 'thetvdb':
             key = 'tvdb'
         unique_ids[key] = str(value)
@@ -172,8 +171,7 @@ def _set_unique_ids(show_info, list_item):
     return list_item
 
 
-def _set_rating(show_info, list_item, default_rating):
-    # type: (InfoType, ListItem, Text) -> ListItem
+def _set_rating(show_info: InfoType, list_item: ListItem, default_rating: str) -> ListItem:
     """Set show rating"""
     imdb_rating = show_info.get('imdb_rating')
     is_imdb_default = default_rating == 'IMDB' and imdb_rating is not None
@@ -186,21 +184,19 @@ def _set_rating(show_info, list_item, default_rating):
     return list_item
 
 
-def _extract_artwork_url(resolutions):
-    # type: (Dict[Text, Text]) -> Text
+def _extract_artwork_url(resolutions: Dict[str, str]) -> str:
     """Extract image URL from the list of available resolutions"""
     url = ''
     for image_size in IMAGE_SIZES:
         url = resolutions.get(image_size) or ''
-        if not isinstance(url, six.text_type):
+        if not isinstance(url, str):
             url = url.get('url') or ''
             if url:
                 break
     return url
 
 
-def _add_season_info(show_info, list_item):
-    # type: (InfoType, ListItem) -> ListItem
+def _add_season_info(show_info: InfoType, list_item: ListItem) -> ListItem:
     """Add info for show seasons"""
     for season in show_info['_embedded']['seasons']:
         list_item.addSeason(season['number'], season.get('name') or '')
@@ -212,20 +208,18 @@ def _add_season_info(show_info, list_item):
     return list_item
 
 
-def _extract_artwork(show_info):
-    # type: (InfoType) -> Dict[Text, List[Dict[Text, Any]]]
+def _extract_artwork(show_info: InfoType) -> Dict[str, List[Dict[str, Any]]]:
     artwork = defaultdict(list)
     for item in show_info['_embedded']['images']:
         artwork[item['type']].append(item)
     return artwork
 
 
-def set_show_artwork(show_info, list_item):
-    # type: (InfoType, ListItem) -> ListItem
+def set_show_artwork(show_info: InfoType, list_item: ListItem) -> ListItem:
     """Set available images for a show"""
     fanart_list = []
     artwork = _extract_artwork(show_info)
-    for artwork_type, artwork_list in six.iteritems(artwork):
+    for artwork_type, artwork_list in artwork.items():
         artwork_list.sort(key=lambda art: art.get('main'), reverse=True)
         for item in artwork_list[:MAX_ARTWORK_NUMBER]:
             resolutions = item.get('resolutions') or {}
@@ -239,8 +233,10 @@ def set_show_artwork(show_info, list_item):
     return list_item
 
 
-def add_main_show_info(list_item, show_info, full_info=True, default_rating='TVmaze'):
-    # type: (ListItem, InfoType, bool, Text) -> ListItem
+def add_main_show_info(list_item: ListItem,
+                       show_info: InfoType,
+                       full_info: bool = True,
+                       default_rating: str = 'TVmaze') -> ListItem:
     """Add main show info to a list item"""
     plot = _clean_plot(show_info.get('summary') or '')
     video = {
@@ -282,8 +278,9 @@ def add_main_show_info(list_item, show_info, full_info=True, default_rating='TVm
     return list_item
 
 
-def add_episode_info(list_item, episode_info, full_info=True):
-    # type: (ListItem, InfoType, bool) -> ListItem
+def add_episode_info(list_item: ListItem,
+                     episode_info: InfoType,
+                     full_info: bool = True) -> ListItem:
     """Add episode info to a list item"""
     video = {
         'title': episode_info['name'],
@@ -299,55 +296,99 @@ def add_episode_info(list_item, episode_info, full_info=True):
             video['plot'] = video['plotoutline'] = _clean_plot(summary)
         if episode_info['runtime'] is not None:
             video['duration'] = episode_info['runtime'] * 60
-        if episode_info['airdate'] is not None:
-            video['premiered'] = episode_info['airdate']
+        image = episode_info.get('image') or {}
+        image_url = _extract_artwork_url(image)
+        if image_url:
+            list_item.addAvailableArtwork(image_url, 'thumb')
+        list_item.setUniqueIDs({'tvmaze': str(episode_info['id'])}, 'tvmaze')
     list_item.setInfo('video', video)
-    image = episode_info.get('image') or {}
-    image_url = _extract_artwork_url(image)
-    if image_url:
-        list_item.addAvailableArtwork(image_url, 'thumb')
-    list_item.setUniqueIDs({'tvmaze': str(episode_info['id'])}, 'tvmaze')
     return list_item
 
 
-def parse_nfo_url(nfo):
-    # type: (Text) -> Optional[UrlParseResult]
+def parse_url_nfo_contents(nfo: str) -> Optional[UrlParseResult]:
     """Extract show ID from NFO file contents"""
     for regexp in SHOW_ID_REGEXPS:
-        show_id_match = regexp.search(nfo)
+        show_id_match = re.search(regexp, nfo, re.I)
         if show_id_match is not None:
             provider = show_id_match.group(1)
             show_id = show_id_match.group(2)
             if provider == 'tvdb':
                 provider = 'thetvdb'
-            logger.debug('Matched show ID {} by regexp {}'.format(show_id, regexp))
+            logger.debug(f'Matched show ID {show_id} by regexp "{regexp}"')
             return UrlParseResult(provider, show_id)
     logger.debug('Unable to find show ID in an NFO file')
     return None
 
 
-def parse_nfo_title_and_year(nfo):
-    # type: (Text) -> [Optional[Text], Optional[Text]]
-    title_match = TITLE_RE.search(nfo)
-    if title_match is None:
-        logger.debug('Unable to find show title in an NFO file')
-        return None, None
-    title = title_match.group(1)
-    year = None
-    year_match = YEAR_RE.search(nfo)
-    if year_match is not None:
-        year = year_match.group(1)
-    if year is None:
-        premiered_match = PREMIERED_RE.search(nfo)
-        if premiered_match is not None:
-            premiered = premiered_match.group(1)
-            year = premiered[:4]
-    logger.debug('Matched title "{}" and year {}'.format(title, year))
-    return title, year
+def parse_url_nfo(nfo: str) -> Optional[InfoType]:
+    show_info = None
+    url_parse_result = parse_url_nfo_contents(nfo)
+    if url_parse_result is not None:
+        if url_parse_result.provider == 'tvmaze':
+            show_info = {'id': int(url_parse_result.show_id)}
+        else:
+            show_info = tvmaze_api.load_show_info_by_external_id(
+                url_parse_result.provider,
+                url_parse_result.show_id
+            )
+    return show_info
 
 
-def _filter_by_year(shows, year):
-    # type: (List[InfoType], Text) -> Optional[InfoType]
+def parse_xml_nfo_contents(nfo: str) -> XmlParseResult:
+    root = Etree.fromstring(nfo)
+    title = ''
+    year = ''
+    uniqueids = {}
+    title_tag = root.find('title')
+    if title_tag is not None:
+        title = title_tag.text
+    year_tag = root.find('year')
+    if year_tag is not None:
+        year = year_tag.text
+    if not year:
+        premiered_tag = root.find('premiered')
+        if premiered_tag is not None:
+            year = premiered_tag.text[:4]
+    for uniqueid_tag in root.findall('uniqueid'):
+        provider = uniqueid_tag.attrib.get('type')
+        if provider is not None:
+            if provider == 'tvdb':
+                provider = 'thetvdb'
+            uniqueids[provider] = uniqueid_tag.text
+    return XmlParseResult(title, year, uniqueids)
+
+
+def parse_tvshow_xml_nfo(nfo: str) -> Optional[InfoType]:
+    show_info = None
+    xml_parse_result = parse_xml_nfo_contents(nfo)
+    if 'tvmaze' in xml_parse_result.uniqueids:
+        show_info = {'id': int(xml_parse_result.uniqueids['tvmaze'])}
+    elif 'imdb' in xml_parse_result.uniqueids:
+        show_info = tvmaze_api.load_show_info_by_external_id(
+            'imdb',
+            xml_parse_result.uniqueids['imdb']
+        )
+    elif 'thetvdb' in xml_parse_result.uniqueids:
+        show_info = tvmaze_api.load_show_info_by_external_id(
+            'thetvdb',
+            xml_parse_result.uniqueids['thetvdb']
+        )
+    if show_info is None and xml_parse_result.title:
+        search_results = search_show(xml_parse_result.title, xml_parse_result.year)
+        if search_results and len(search_results) == 1:
+            show_info = search_results[0]
+    return show_info
+
+
+def parse_episode_xml_nfo(nfo: str) -> Optional[InfoType]:
+    episode_info = None
+    parse_result = parse_xml_nfo_contents(nfo)
+    if 'tvmaze' in parse_result.uniqueids:
+        episode_info = {'id': int(parse_result.uniqueids['tvmaze'])}
+    return episode_info
+
+
+def _filter_by_year(shows: List[InfoType], year: str) -> Optional[InfoType]:
     """
     Filter a show by year
 
@@ -362,9 +403,8 @@ def _filter_by_year(shows, year):
     return None
 
 
-def search_show(title, year):
-    # type: (Text, Text) -> List[InfoType]
-    logger.debug('Searching for TV show {} ({})'.format(title, year))
+def search_show(title: str, year: str) -> Sequence[InfoType]:
+    logger.debug(f'Searching for TV show {title} ({year})')
     raw_search_results = tvmaze_api.search_show(title)
     search_results = [res['show'] for res in raw_search_results]
     if len(search_results) > 1 and year:

--- a/metadata.tvmaze/libs/exception_logger.py
+++ b/metadata.tvmaze/libs/exception_logger.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # (c) Roman Miroshnychenko <roman1972@gmail.com> 2020
 #
 # This program is free software: you can redistribute it and/or modify
@@ -14,51 +13,42 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Exception logger with extended diagnostic info"""
-from __future__ import absolute_import, unicode_literals
-
 import inspect
 import sys
 from contextlib import contextmanager
 from platform import uname
 from pprint import pformat
+from typing import List, Dict, Callable, Generator, Any
 
-import six
 import xbmc
 
 from .utils import logger
 
-try:
-    from typing import Text, Dict, List, Callable, Generator  # pylint: disable=unused-import
-except ImportError:
-    pass
 
-
-def _format_vars(variables):
-    # type: (dict) -> Text
+def _format_vars(variables: Dict[str, Any]) -> str:
     """
     Format variables dictionary
 
     :param variables: variables dict
     :return: formatted string with sorted ``var = val`` pairs
     """
-    var_list = [(var, val) for var, val in six.iteritems(variables)
+    var_list = [(var, val) for var, val in variables.items()
                 if not (var.startswith('__') or var.endswith('__'))]
     var_list.sort(key=lambda i: i[0])
     lines = []
     for var, val in var_list:
-        lines.append('{} = {}'.format(var, pformat(val, indent=4)))
+        lines.append(f'{var} = {pformat(val, indent=4)}')
     return '\n'.join(lines)
 
 
-def _format_code_context(code_context, lineno, index):
-    # type: (List[Text], int, int) -> Text
+def _format_code_context(code_context: List[str], lineno: int, index: int) -> str:
     context = ''
     if code_context is not None:
         for i, line in enumerate(code_context, lineno - index):
             if i == lineno:
-                context += '{}:>{}'.format(six.text_type(i).rjust(5), line)
+                context += f'{str(i).rjust(5)}:>{line}'
             else:
-                context += '{}: {}'.format(six.text_type(i).rjust(5), line)
+                context += f'{str(i).rjust(5)}: {line}'
     return context
 
 
@@ -74,8 +64,7 @@ Local variables:
 """
 
 
-def _format_frame_info(frame_info):
-    # type: (tuple) -> Text
+def _format_frame_info(frame_info: tuple) -> str:
     return FRAME_INFO_TEMPLATE.format(
         file_path=frame_info[1],
         lineno=frame_info[2],
@@ -108,8 +97,7 @@ sys.path:
 
 
 @contextmanager
-def log_exception(logger_func=logger.error):
-    # type: (Callable[[Text], None]) -> Generator[None, None, None]
+def log_exception(logger_func: Callable[[str], None] = logger.error) -> Generator[None, None, None]:
     """
     Diagnostic helper context manager
 
@@ -149,7 +137,7 @@ def log_exception(logger_func=logger.error):
             system_info=uname(),
             python_version=sys.version.replace('\n', ' '),
             kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
-            sys_argv=six.text_type(sys.argv),
+            sys_argv=str(sys.argv),
             sys_path=pformat(sys.path),
             stack_trace=stack_trace
         )

--- a/metadata.tvmaze/libs/imdb_rating.py
+++ b/metadata.tvmaze/libs/imdb_rating.py
@@ -1,23 +1,29 @@
-# coding: utf-8
-from __future__ import absolute_import, unicode_literals
+# Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import re
+from typing import Dict, Union, Optional
 
-import requests
-
+from . import simple_requests as requests
 from .utils import logger
-
-try:
-    from typing import Text, Dict, Union, Optional  # pylint: disable=unused-import
-except ImportError:
-    pass
 
 IMDB_TITLE_URL = 'https://www.imdb.com/title/{}/'
 
 
-def get_imdb_rating(imdb_id):
-    # type: (Text) -> Optional[Dict[Text, Union[int, float]]]
+def get_imdb_rating(imdb_id: str) -> Optional[Dict[str, Union[int, float]]]:
     url = IMDB_TITLE_URL.format(imdb_id)
     response = requests.get(url)
     if response.ok:
@@ -30,6 +36,6 @@ def get_imdb_rating(imdb_id):
                 rating = aggregate_rating['ratingValue']
                 votes = aggregate_rating['ratingCount']
                 return {'rating': rating, 'votes': votes}
-    logger.debug('Unable to get IMDB rating for ID {}. Status: {}, response: {}'.format(
-        imdb_id, response.status_code, response.text))
+    logger.debug(f'Unable to get IMDB rating for ID {imdb_id}. '
+                 f'Status: {response.status_code}, response: {response.text}')
     return None

--- a/metadata.tvmaze/libs/simple_requests.py
+++ b/metadata.tvmaze/libs/simple_requests.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+A simple library for making HTTP requests with API similar to the popular "requests" library
+It depends only on the Python standard library.
+Supported:
+* HTTP methods: GET, POST
+* HTTP and HTTPS.
+* Disabling SSL certificates validation.
+* Request payload as form data and JSON.
+* Custom headers.
+* Basic authentication.
+* Gzipped response content.
+Not supported:
+* Cookies.
+* File upload.
+"""
+# pylint: skip-file
+import gzip
+import io
+import json as _json
+import ssl
+from base64 import b64encode
+from email.message import Message
+from typing import Optional, Dict, Any, Tuple, Union, List
+from urllib import request as url_request
+from urllib.error import HTTPError as _HTTPError
+from urllib.parse import urlparse, urlencode
+
+__all__ = [
+    'RequestException',
+    'ConnectionError',
+    'HTTPError',
+    'get',
+    'post',
+]
+
+
+class RequestException(IOError):
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class ConnectionError(RequestException):
+
+    def __init__(self, message: str, url: str):
+        super().__init__(message)
+        self.message = message
+        self.url = url
+
+    def __str__(self) -> str:
+        return f'ConnectionError for url {self.url}: {self.message}'
+
+
+class HTTPError(RequestException):
+
+    def __init__(self, response: 'Response'):
+        self.response = response
+
+    def __str__(self) -> str:
+        return f'HTTPError: {self.response.status_code} for url: {self.response.url}'
+
+
+class HTTPMessage(Message):
+
+    def update(self, dct: Dict[str, str]) -> None:
+        for key, value in dct.items():
+            self[key] = value
+
+
+class Response:
+    NULL = object()
+
+    def __init__(self):
+        self.encoding: str = 'utf-8'
+        self.status_code: int = -1
+        self.headers: Dict[str, str] = {}
+        self.url: str = ''
+        self.content: bytes = b''
+        self._text = None
+        self._json = self.NULL
+
+    def __str__(self) -> str:
+        return f'<Response [{self.status_code}]>'
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    @property
+    def text(self) -> str:
+        """
+        :return: Response payload as decoded text
+        """
+        if self._text is None:
+            self._text = self.content.decode(self.encoding)
+        return self._text
+
+    def json(self) -> Optional[Union[Dict[str, Any], List[Any]]]:
+        try:
+            if self._json is self.NULL:
+                self._json = _json.loads(self.content)
+            return self._json
+        except ValueError as exc:
+            raise ValueError('Response content is not a valid JSON') from exc
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            raise HTTPError(self)
+
+
+def _create_request(url_structure, params=None, data=None, headers=None, auth=None, json=None):
+    query = url_structure.query
+    if params is not None:
+        separator = '&' if query else ''
+        query += separator + urlencode(params, doseq=True)
+    full_url = url_structure.scheme + '://' + url_structure.netloc + url_structure.path
+    if query:
+        full_url += '?' + query
+    prepared_headers = HTTPMessage()
+    if headers is not None:
+        prepared_headers.update(headers)
+    body = None
+    if json is not None:
+        body = _json.dumps(json).encode('utf-8')
+        prepared_headers['Content-Type'] = 'application/json'
+    if body is None and data is not None:
+        body = urlencode(data, doseq=True).encode('ascii')
+        prepared_headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if auth is not None:
+        encoded_credentials = b64encode((auth[0] + ':' + auth[1]).encode('utf-8')).decode('ascii')
+        prepared_headers['Authorization'] = f'Basic {encoded_credentials}'
+    if 'Accept-Encoding' not in prepared_headers:
+        prepared_headers['Accept-Encoding'] = 'gzip'
+    return url_request.Request(full_url, body, prepared_headers)
+
+
+def post(url: str,
+         params: Optional[Dict[str, Any]] = None,
+         data: Optional[Dict[str, Any]] = None,
+         headers: Optional[Dict[str, str]] = None,
+         auth: Optional[Tuple[str, str]] = None,
+         timeout: Optional[float] = None,
+         verify: bool = True,
+         json: Optional[Dict[str, Any]] = None) -> Response:
+    """
+    POST request
+    This function assumes that a request body should be encoded with UTF-8
+    and by default sends Accept-Encoding: gzip header to receive response content compressed.
+    :param url: URL
+    :param params: URL query params
+    :param data: request payload as form data. If "data" or "json" are passed
+        then a POST request is sent
+    :param headers: additional headers
+    :param auth: a tuple of (login, password) for Basic authentication
+    :param timeout: request timeout in seconds
+    :param verify: verify SSL certificates
+    :param json: request payload as JSON. This parameter has precedence over "data", that is,
+        if it's present then "data" is ignored.
+    :return: Response object
+    """
+    url_structure = urlparse(url)
+    request = _create_request(url_structure, params, data, headers, auth, json)
+    context = None
+    if url_structure.scheme == 'https':
+        context = ssl.SSLContext()
+        if not verify:
+            context.verify_mode = ssl.CERT_NONE
+            context.check_hostname = False
+    fp = None
+    try:
+        r = fp = url_request.urlopen(request, timeout=timeout, context=context)
+        content = fp.read()
+    except _HTTPError as exc:
+        r = exc
+        fp = exc.fp
+        content = fp.read()
+    except Exception as exc:
+        raise ConnectionError(str(exc), request.full_url) from exc
+    finally:
+        if fp is not None:
+            fp.close()
+    response = Response()
+    response.status_code = r.status if hasattr(r, 'status') else r.getstatus()
+    response.headers = r.headers
+    response.url = r.url if hasattr(r, 'url') else r.geturl()
+    if r.headers.get('Content-Encoding') == 'gzip':
+        temp_fo = io.BytesIO(content)
+        gzip_file = gzip.GzipFile(fileobj=temp_fo)
+        content = gzip_file.read()
+    response.content = content
+    return response
+
+
+def get(url: str,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        timeout: Optional[float] = None,
+        verify: bool = True) -> Response:
+    """
+    GET request
+    This function by default sends Accept-Encoding: gzip header
+    to receive response content compressed.
+    :param url: URL
+    :param params: URL query params
+    :param headers: additional headers
+    :param auth: a tuple of (login, password) for Basic authentication
+    :param timeout: request timeout in seconds
+    :param verify: verify SSL certificates
+    :return: Response object
+    """
+    return post(url=url, params=params, headers=headers, auth=auth, timeout=timeout, verify=verify)

--- a/metadata.tvmaze/libs/tvmaze_api.py
+++ b/metadata.tvmaze/libs/tvmaze_api.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-#
 # Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -17,22 +15,15 @@
 
 """Functions to interact with TVmaze API"""
 
-from __future__ import absolute_import, unicode_literals
-
 from pprint import pformat
-
-import requests
-from requests.exceptions import HTTPError
+from typing import Text, Optional, Union, List, Dict, Any
 
 from . import cache_service as cache
+from . import simple_requests as requests
 from .imdb_rating import get_imdb_rating
 from .utils import logger
 
-try:
-    from typing import Text, Optional, Union, List, Dict, Any  # pylint: disable=unused-import
-    InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
-except ImportError:
-    pass
+InfoType = Dict[str, Any]  # pylint: disable=invalid-name
 
 SEARCH_URL = 'http://api.tvmaze.com/search/shows'
 SEARCH_BY_EXTERNAL_ID_URL = 'http://api.tvmaze.com/lookup/shows'
@@ -46,12 +37,10 @@ HEADERS = (
     ('User-Agent', 'Kodi scraper for tvmaze.com by Roman V.M.'),
     ('Accept', 'application/json'),
 )
-SESSION = requests.Session()
-SESSION.headers.update(dict(HEADERS))
 
 
-def _load_info(url, params=None):
-    # type: (Text, Optional[Dict[Text, Union[Text, List[Text]]]]) -> Union[dict, list]
+def _load_info(url: str,
+               params: Optional[Dict[Text, Union[Text, List[Text]]]] = None) -> Union[dict, list]:
     """
     Load info from TVmaze
 
@@ -60,17 +49,16 @@ def _load_info(url, params=None):
     :return: API response
     :raises requests.exceptions.HTTPError: if any error happens
     """
-    logger.debug('Calling URL "{}" with params {}'.format(url, params))
-    response = SESSION.get(url, params=params)
+    logger.debug(f'Calling URL "{url}" with params {params}')
+    response = requests.get(url, params=params, headers=dict(HEADERS))
     if not response.ok:
         response.raise_for_status()
     json_response = response.json()
-    logger.debug('TVmaze response:\n{}'.format(pformat(json_response)))
+    logger.debug(f'TVmaze response:\n{pformat(json_response)}')
     return json_response
 
 
-def search_show(title):
-    # type: (Text) -> List[InfoType]
+def search_show(title: str) -> List[InfoType]:
     """
     Search a single TV show
 
@@ -79,13 +67,12 @@ def search_show(title):
     """
     try:
         return _load_info(SEARCH_URL, {'q': title})
-    except HTTPError as exc:
-        logger.error('TVmaze returned an error: {}'.format(exc))
+    except requests.HTTPError as exc:
+        logger.error(f'TVmaze returned an error: {exc}')
         return []
 
 
-def load_show_info(show_id):
-    # type: (Text) -> Optional[InfoType]
+def load_show_info(show_id: str) -> Optional[InfoType]:
     """
     Get full info for a single show
 
@@ -98,8 +85,8 @@ def load_show_info(show_id):
         params = {'embed[]': ['cast', 'seasons', 'images', 'crew']}
         try:
             show_info = _load_info(show_info_url, params)
-        except HTTPError as exc:
-            logger.error('TVmaze returned an error: {}'.format(exc))
+        except requests.HTTPError as exc:
+            logger.error(f'TVmaze returned an error: {exc}')
             return None
         if isinstance(show_info['_embedded']['images'], list):
             show_info['_embedded']['images'].sort(key=lambda img: img['main'],
@@ -114,8 +101,7 @@ def load_show_info(show_id):
     return show_info
 
 
-def load_show_info_by_external_id(provider, show_id):
-    # type: (Text, Text) -> Optional[InfoType]
+def load_show_info_by_external_id(provider: str, show_id: str) -> Optional[InfoType]:
     """
     Load show info by external ID (TheTVDB or IMDB)
 
@@ -126,19 +112,18 @@ def load_show_info_by_external_id(provider, show_id):
     query = {provider: show_id}
     try:
         return _load_info(SEARCH_BY_EXTERNAL_ID_URL, query)
-    except HTTPError as exc:
-        logger.error('TVmaze returned an error: {}'.format(exc))
+    except requests.HTTPError as exc:
+        logger.error(f'TVmaze returned an error: {exc}')
         return None
 
 
-def _get_alternate_episode_list_id(show_id, episode_order):
-    # type: (Text, Text) -> Optional[int]
+def _get_alternate_episode_list_id(show_id: str, episode_order: str) -> Optional[int]:
     alternate_order_id = None
     url = ALTERNATE_LISTS_URL.format(show_id)
     try:
         alternate_lists = _load_info(url)
-    except HTTPError as exc:
-        logger.error('TVmaze returned an error: {}'.format(exc))
+    except requests.HTTPError as exc:
+        logger.error(f'TVmaze returned an error: {exc}')
     else:
         for episode_list in alternate_lists:
             if episode_list.get(episode_order):
@@ -147,16 +132,15 @@ def _get_alternate_episode_list_id(show_id, episode_order):
     return alternate_order_id
 
 
-def load_alternate_episode_list(show_id, episode_order):
-    # type: (Text, Text) -> Optional[List[InfoType]]
+def load_alternate_episode_list(show_id: str, episode_order: str) -> Optional[List[InfoType]]:
     alternate_episodes = None
     alternate_order_id = _get_alternate_episode_list_id(show_id, episode_order)
     if alternate_order_id is not None:
         url = ALTERNATE_EPISODES_URL.format(alternate_order_id)
         try:
             raw_alternate_episodes = _load_info(url, {'embed': 'episodes'})
-        except HTTPError as exc:
-            logger.error('TVmaze returned an error: {}'.format(exc))
+        except requests.HTTPError as exc:
+            logger.error(f'TVmaze returned an error: {exc}')
         else:
             alternate_episodes = []
             for episode in raw_alternate_episodes:
@@ -169,8 +153,7 @@ def load_alternate_episode_list(show_id, episode_order):
     return alternate_episodes
 
 
-def load_episode_list(show_id, episode_order):
-    # type: (Text, Text) -> Optional[List[InfoType]]
+def load_episode_list(show_id: str, episode_order: str) -> Optional[List[InfoType]]:
     """Load episode list from TVmaze API"""
     episode_list = None
     if episode_order != 'default':
@@ -179,16 +162,15 @@ def load_episode_list(show_id, episode_order):
         episode_list_url = EPISODE_LIST_URL.format(show_id)
         try:
             episode_list = _load_info(episode_list_url, {'specials': '1'})
-        except HTTPError as exc:
-            logger.error('TVmaze returned an error: {}'.format(exc))
+        except requests.HTTPError as exc:
+            logger.error(f'TVmaze returned an error: {exc}')
     return episode_list
 
 
-def load_episode_info(episode_id):
-    # type: (Union[Text, int]) -> Optional[InfoType]
+def load_episode_info(episode_id: Union[str, int]) -> Optional[InfoType]:
     url = EPISODE_INFO_URL.format(episode_id)
     try:
         return _load_info(url)
-    except HTTPError as exc:
-        logger.error('TVmaze returned an error: {}'.format(exc))
+    except requests.HTTPError as exc:
+        logger.error(f'TVmaze returned an error: {exc}')
         return None

--- a/metadata.tvmaze/libs/utils.py
+++ b/metadata.tvmaze/libs/utils.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-#
 # Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,20 +14,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Misc utils"""
-
-from __future__ import absolute_import, unicode_literals
+from typing import Text, Any, Dict
 
 import xbmc
-from six import PY2, text_type, binary_type
 from xbmcaddon import Addon
-
-try:
-    from typing import Text, Optional, Any, Dict  # pylint: disable=unused-import
-except ImportError:
-    pass
 
 ADDON = Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
+VERSION = ADDON.getAddonInfo('version')
 
 EPISODE_ORDER_MAP = {
     0: 'default',
@@ -43,38 +35,33 @@ EPISODE_ORDER_MAP = {
 
 
 class logger:
-    log_message_prefix = '[{} ({})]: '.format(ADDON_ID, ADDON.getAddonInfo('version'))
+    log_message_prefix = f'[{ADDON_ID} ({VERSION})]: '
 
     @staticmethod
-    def log(message, level=xbmc.LOGDEBUG):
-        # type: (Text, int) -> None
-        if isinstance(message, binary_type):
-            message = message.decode('utf-8')
+    def log(message: str, level: int = xbmc.LOGDEBUG) -> None:
         message = logger.log_message_prefix + message
-        if PY2 and isinstance(message, text_type):
-            message = message.encode('utf-8')
         xbmc.log(message, level)
 
-    @staticmethod
-    def info(message):
-        # type: (Text) -> None
-        logger.log(message, xbmc.LOGINFO)
+    @classmethod
+    def info(cls, message: str) -> None:
+        cls.log(message, xbmc.LOGINFO)
 
-    @staticmethod
-    def error(message):
-        # type: (Text) -> None
-        logger.log(message, xbmc.LOGERROR)
+    @classmethod
+    def error(cls, message: str) -> None:
+        cls.log(message, xbmc.LOGERROR)
 
-    @staticmethod
-    def debug(message):
-        # type: (Text) -> None
+    @classmethod
+    def debug(cls, message: str) -> None:
         logger.log(message, xbmc.LOGDEBUG)
 
+    @classmethod
+    def warning(cls, message: str) -> None:
+        logger.log(message, xbmc.LOGWARNING)
 
-def get_episode_order(path_settings):
-    # type: (Dict[Text, Any]) -> Text
+
+def get_episode_order(path_settings: Dict[Text, Any]) -> str:
     episode_order_enum = path_settings.get('episode_order')
     if episode_order_enum is None:
-        episode_order_enum = int(ADDON.getSetting('episode_order'))
+        episode_order_enum = ADDON.getSettingInt('episode_order')
     episode_order = EPISODE_ORDER_MAP.get(episode_order_enum, 'default')
     return episode_order

--- a/metadata.tvmaze/main.py
+++ b/metadata.tvmaze/main.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-#
 # Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -15,9 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=missing-docstring
-
-from __future__ import absolute_import
-
 import sys
 
 from libs.actions import router

--- a/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.tvmaze/resources/language/resource.language.en_gb/strings.po
@@ -46,3 +46,7 @@ msgstr ""
 msgctxt "#32009"
 msgid "Default Rating"
 msgstr ""
+
+msgctxt "#32010"
+msgid ".NFO files include full show/episodes information"
+msgstr ""

--- a/metadata.tvmaze/resources/settings.xml
+++ b/metadata.tvmaze/resources/settings.xml
@@ -1,9 +1,41 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-    <category label="32000">
-      <setting label="32001" type="enum" id="episode_order"
-               lvalues="32002|32003|32004|32005|32006|32007|32008"/>
-      <setting label="32009" type="labelenum" id="default_rating"
-               values="TVmaze|IMDB"/>
+<settings version="1">
+  <section id="metadata.tvmaze">
+    <category id="general" label="32000">
+      <group id="1">
+        <setting id="episode_order" type="integer" label="32001" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32002">0</option>
+              <option label="32003">1</option>
+              <option label="32004">2</option>
+              <option label="32005">3</option>
+              <option label="32006">4</option>
+              <option label="32007">5</option>
+              <option label="32000">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string"/>
+        </setting>
+        <setting id="default_rating" type="string" label="32009" help="">
+          <level>0</level>
+          <default>TVmaze</default>
+          <constraints>
+            <options>
+              <option label="TVmaze">TVmaze</option>
+              <option label="IMDB">IMDB</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string"/>
+        </setting>
+        <setting id="full_nfo" type="boolean" label="32010" help="">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
+      </group>
     </category>
+  </section>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.3.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.3.0:

- Improved parsing of NFO files.
- Completely removed Python 2 support.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
