### PR TITLE
[metadata.tvmaze@matrix] 1.3.1

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.3.0"
+  version="1.3.1"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -20,8 +20,10 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.3.0:
+    <news>1.3.1:
+- Fixed import error.
 
+1.3.0:
 - Improved parsing of NFO files.
 - Completely removed Python 2 support.</news>
     <reuselanguageinvoker>false</reuselanguageinvoker>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -18,10 +18,10 @@
 import json
 import sys
 from typing import Optional
+from urllib import parse as urllib_parse
 
 import xbmcgui
 import xbmcplugin
-from six.moves import urllib_parse
 
 from . import tvmaze_api, data_service
 from .utils import logger, get_episode_order, ADDON

--- a/metadata.tvmaze/libs/simple_requests.py
+++ b/metadata.tvmaze/libs/simple_requests.py
@@ -14,7 +14,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 A simple library for making HTTP requests with API similar to the popular "requests" library
+
 It depends only on the Python standard library.
+
 Supported:
 * HTTP methods: GET, POST
 * HTTP and HTTPS.
@@ -161,8 +163,10 @@ def post(url: str,
          json: Optional[Dict[str, Any]] = None) -> Response:
     """
     POST request
+
     This function assumes that a request body should be encoded with UTF-8
     and by default sends Accept-Encoding: gzip header to receive response content compressed.
+
     :param url: URL
     :param params: URL query params
     :param data: request payload as form data. If "data" or "json" are passed
@@ -216,8 +220,10 @@ def get(url: str,
         verify: bool = True) -> Response:
     """
     GET request
+
     This function by default sends Accept-Encoding: gzip header
     to receive response content compressed.
+
     :param url: URL
     :param params: URL query params
     :param headers: additional headers


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.3.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.3.1:
- Fixed import error.

1.3.0:
- Improved parsing of NFO files.
- Completely removed Python 2 support.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
