### PR TITLE
[metadata.tvshows.thesportsdb.python] v1.1.0

### DIFF
--- a/metadata.tvshows.thesportsdb.python/addon.xml
+++ b/metadata.tvshows.thesportsdb.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.thesportsdb.python"
   name="The SportsDB TV Shows"
-  version="1.0.11"
+  version="1.1.0"
   provider-name="pkscout">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -9,6 +9,10 @@
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="00:15"/>
   <extension point="xbmc.addon.metadata">
+    <news>1.1.0
+change to use new JSON based episodeguide format to handle multiple providers
+fixes for last minute changes to new Nexus Python bindings
+    </news>
     <platform>all</platform>
     <license>GPL-3.0-or-later</license>
     <assets>

--- a/metadata.tvshows.thesportsdb.python/changelog.txt
+++ b/metadata.tvshows.thesportsdb.python/changelog.txt
@@ -1,3 +1,7 @@
+1.1.0
+change to use new JSON based episodeguide format to handle multiple providers
+fixes for last minute changes to the Nexus Python bindings
+
 1.0.11
 added option to select language for league and game summaries
 

--- a/metadata.tvshows.thesportsdb.python/libs/data_utils.py
+++ b/metadata.tvshows.thesportsdb.python/libs/data_utils.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
+import json
 from xbmc import Actor
 from collections import namedtuple
 from .utils import url_fix, logger
@@ -131,7 +132,7 @@ def _set_artwork(images, list_item):
             else:
                 previewurl = theurl + '/preview'
                 vtag.addAvailableArtwork(
-                    theurl, art_type=image_type, preview=previewurl)
+                    theurl, arttype=image_type, preview=previewurl)
     if fanart_list:
         list_item.setAvailableFanart(fanart_list)
     return list_item
@@ -169,13 +170,14 @@ def add_main_show_info(list_item, show_info, full_info=True):
     vtag.setOriginalTitle(showname)
     vtag.setTvShowTitle(showname)
     vtag.setMediaType('tvshow')
-    vtag.setEpisodeGuide(str(show_info['idLeague']))
+    epguide = {'tsdb': str(show_info['idLeague'])}
+    vtag.setEpisodeGuide(json.dumps(epguide))
     vtag.setYear(int(show_info.get('intFormedYear', '')[:4]))
     vtag.setPremiered(show_info.get('dateFirstEvent', ''))
     if full_info:
         _set_plot(show_info, vtag)
         vtag.setUniqueID(show_info.get('idLeague'),
-                         type='tsdb', isDefault=True)
+                         type='tsdb', isdefault=True)
         vtag.setGenres([show_info.get('strSport', '')])
         tvrights = show_info.get('strTvRights', '')
         if tvrights:
@@ -193,7 +195,7 @@ def add_main_show_info(list_item, show_info, full_info=True):
             theurl = url_fix(image)
             previewurl = theurl + '/preview'
             vtag.addAvailableArtwork(
-                theurl, art_type='poster', preview=previewurl)
+                theurl, arttype='poster', preview=previewurl)
     logger.debug(
         'adding sports league information for %s to list item' % showname)
     return list_item


### PR DESCRIPTION
### Description
- change to use new JSON based episodeguide format to handle multiple providers
- fixes for last minute changes to the Nexus Python bindings
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
