### PR TITLE
[metadata.tvmaze@matrix] 1.3.3

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.3.2"
+  version="1.3.3"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -20,7 +20,7 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.3.2:
+    <news>1.3.3:
 - Internal changes.
     </news>
     <reuselanguageinvoker>false</reuselanguageinvoker>

--- a/metadata.tvmaze/libs/cache_service.py
+++ b/metadata.tvmaze/libs/cache_service.py
@@ -23,11 +23,6 @@ from typing import Optional, Text, Dict, Any, Union
 import xbmcgui
 import xbmcvfs
 
-try:
-    from xbmcvfs import translatePath
-except ImportError:
-    from xbmc import translatePath
-
 from .utils import ADDON_ID, logger
 
 EPISODES_CACHE_TTL = 60 * 10  # 10 minutes
@@ -81,7 +76,7 @@ def load_episodes_map_from_cache(show_id: Union[int, str]) -> Optional[Dict[str,
 
 
 def _get_cache_directory() -> str:  # pylint: disable=missing-docstring
-    temp_dir = translatePath('special://temp')
+    temp_dir = xbmcvfs.translatePath('special://temp')
     if isinstance(temp_dir, bytes):
         temp_dir = temp_dir.decode('utf-8')
     cache_dir = os.path.join(temp_dir, 'scrapers', ADDON_ID)

--- a/metadata.tvmaze/libs/data_service.py
+++ b/metadata.tvmaze/libs/data_service.py
@@ -47,6 +47,7 @@ CLEAN_PLOT_REPLACEMENTS = (
     ('</i>', '[/I]'),
     ('</p><p>', '[CR]'),
 )
+SUPPORTED_EXTERNAL_IDS = ('tvdb', 'imdb')
 
 
 class UrlParseResult(NamedTuple):
@@ -312,8 +313,6 @@ def parse_url_nfo_contents(nfo: str) -> Optional[UrlParseResult]:
         if show_id_match is not None:
             provider = show_id_match.group(1)
             show_id = show_id_match.group(2)
-            if provider == 'tvdb':
-                provider = 'thetvdb'
             logger.debug(f'Matched show ID {show_id} by regexp "{regexp}"')
             return UrlParseResult(provider, show_id)
     logger.debug('Unable to find show ID in an NFO file')
@@ -370,7 +369,7 @@ def parse_tvshow_xml_nfo(nfo: str) -> Optional[InfoType]:
         )
     elif 'thetvdb' in xml_parse_result.uniqueids:
         show_info = tvmaze_api.load_show_info_by_external_id(
-            'tvdb',
+            'thetvdb',
             xml_parse_result.uniqueids['thetvdb']
         )
     if show_info is None and xml_parse_result.title:
@@ -420,7 +419,7 @@ def parse_json_episogeguide(episodeguide: str) -> Optional[str]:
         return None
     show_id = uniqueids.get('tvmaze')
     if show_id is None:
-        for external_id_type in ('tvdb', 'imdb'):
+        for external_id_type in SUPPORTED_EXTERNAL_IDS:
             external_id = uniqueids.get(external_id_type)
             if external_id is not None:
                 if external_id == 'tvdb':


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.3.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.3.3:
- Internal changes.
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
