### PR TITLE
[metadata.tvshows.thetvdb.com.v4.python@matrix] 1.1.4

### DIFF
--- a/metadata.tvshows.thetvdb.com.v4.python/addon.xml
+++ b/metadata.tvshows.thetvdb.com.v4.python/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.thetvdb.com.v4.python" name="The TVDB v4"
-       version="1.1.3" provider-name="TVDB Team">
+       version="1.1.4" provider-name="TVDB Team">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
     <import addon="xbmc.python" version="3.0.0" />
@@ -121,6 +121,6 @@
       <screenshot>media/screenshot-2.jpg</screenshot>
       <screenshot>media/screenshot-3.jpg</screenshot>
     </assets>
-    <news>- 1.1.3: Fix minor bugs with specials and error handling.</news>
+    <news>- 1.1.4: New episode guide format and fix for specials seasons order</news>
   </extension>
 </addon>

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/episodes.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/episodes.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 import xbmcgui
 import xbmcplugin
+import json
 
 from . import tvdb
 from .nfo import parse_episode_guide_url
@@ -12,27 +13,41 @@ from .series import get_unique_ids, ARTWORK_URL_PREFIX
 # add the episodes of a series to the list
 
 
-def get_series_episodes(id, settings, handle):
+def get_series_episodes(show_ids, settings, handle):
     logger.debug(f'Find episodes of tvshow with id {id}')
-    if not id.isdigit():
+    try:
+        all_ids = json.loads(show_ids)
+        show_id = all_ids.get('tvdb')
+        if not show_id:
+            show_id = str(show_ids)
+    except (ValueError, AttributeError):
+        show_id = str(show_ids)
+        if show_id.isdigit():
+            logger.error(
+                'using deprecated episodeguide format, this show should be refreshed or rescraped')
+    if not show_id:
+        raise RuntimeError(
+            'No tvdb show id found in episode guide, this show should be refreshed or rescraped')
+    elif not str(show_id).isdigit():
         # Kodi has a bug: when a show directory contains an XML NFO file with
         # episodeguide URL, that URL is always passed here regardless of
         # the actual parsing result in get_show_id_from_nfo()
-        parse_result = parse_episode_guide_url(id)
+        parse_result = parse_episode_guide_url(show_id)
         if not parse_result:
             return
 
         if parse_result.provider == 'thetvdb':
-            id = parse_result.show_id
-            logger.debug(f'Changed show id to {id}')
+            show_id = parse_result.show_id
+            logger.debug(f'Changed show id to {show_id}')
 
     client = tvdb.Client(settings)
-    episodes = client.get_series_episodes_api(id, settings)
+    episodes = client.get_series_episodes_api(show_id, settings)
 
     if not episodes:
         xbmcplugin.setResolvedUrl(
             handle, False, xbmcgui.ListItem(offscreen=True))
         return
+
     for ep in episodes:
         liz = xbmcgui.ListItem(ep['name'], offscreen=True)
         details = {
@@ -57,8 +72,6 @@ def get_series_episodes(id, settings, handle):
             )
 
 # get the details of the found episode
-
-
 def get_episode_details(id, settings, handle):
     logger.debug(f'Find info of episode with id {id}')
     client = tvdb.Client(settings)
@@ -88,10 +101,12 @@ def get_episode_details(id, settings, handle):
 
     if ep.get("airsAfterSeason"):
         details['sortseason'] = ep.get("airsAfterSeason") + 1
+        details['sortepisode'] = 0
     if ep.get("airsBeforeSeason"):
-        details['sortseason'] = ep.get("airsBeforeSeason") - 1
+        details['sortseason'] = ep.get("airsBeforeSeason")
+        details['sortepisode'] = 0
     if ep.get("airsBeforeEpisode"):
-        details['sortepisode'] = ep.get("airsBeforeEpisode") - 1
+        details['sortepisode'] = ep.get("airsBeforeEpisode")
 
     if tags:
         details["tag"] = tags

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/series.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/series.py
@@ -2,6 +2,7 @@ from pprint import pformat
 
 import xbmcgui
 import xbmcplugin
+import json
 
 from . import tvdb
 from .artwork import add_artworks
@@ -70,11 +71,19 @@ def get_series_details(id, settings, handle):
         xbmcplugin.setResolvedUrl(
             handle, False, xbmcgui.ListItem(offscreen=True))
         return
+
+    showId = {'tvdb': str(show["id"])}
+    for remoteId in show.get('remoteIds'):
+        if remoteId.get('sourceName') == "IMDB":
+            showId['imdb'] = remoteId.get('id')
+        if remoteId.get('sourceName') == "TheMovieDB.com":
+            showId['tmdb'] = remoteId.get('id')
+    
     details = {'title': show["name"],
                 'tvshowtitle': show["name"],
                 'plot': show["overview"],
                 'plotoutline': show["overview"],
-                'episodeguide': show["id"],
+                'episodeguide': json.dumps(showId),
                 'mediatype': 'tvshow',
                 }
     name = show["name"]


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The TVDB v4
  - Add-on ID: metadata.tvshows.thetvdb.com.v4.python
  - Version number: 1.1.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thetvdb/metadata.tvshows.thetvdb.com.v4.python
  
TheTVDB.com is a TV Scraper. The site is a massive open database that can be modified by anybody and contains full meta data for many shows in different languages. All content and images on the site have been contributed by their users for users and have a high standard or quality. The database schema and website are open source under the GPL.

### Description of changes:

- 1.1.4:New episode guide format and fix for specials seasons order.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
