### PR TITLE
[metadata.tvmaze@matrix] 1.3.4

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.3.3"
+  version="1.3.4"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -20,9 +20,9 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.3.3:
+    <news>1.3.4:
 - Internal changes.
     </news>
-    <reuselanguageinvoker>false</reuselanguageinvoker>
+    <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>

--- a/metadata.tvmaze/libs/actions.py
+++ b/metadata.tvmaze/libs/actions.py
@@ -108,7 +108,7 @@ def get_details(show_id: str, default_rating: str) -> None:
 
 
 def get_episode_list(episodeguide: str, episode_order: str) -> None:  # pylint: disable=missing-docstring
-    logger.debug(f'Getting episode list for show id {episodeguide}, order: {episode_order}')
+    logger.debug(f'Getting episode list for episodeguide {episodeguide}, order: {episode_order}')
     show_id = None
     if episodeguide.startswith('{'):
         show_id = data_service.parse_json_episogeguide(episodeguide)
@@ -116,9 +116,6 @@ def get_episode_list(episodeguide: str, episode_order: str) -> None:  # pylint: 
             logger.error(f'Unable to determine TVmaze show ID from episodeguide: {episodeguide}')
             return
     if show_id is None and not episodeguide.isdigit():
-        # Kodi has a bug: when a show directory contains an XML NFO file with
-        # episodeguide URL, that URL is always passed here regardless of
-        # the actual parsing result in get_show_from_nfo()
         logger.warning(f'Invalid episodeguide format: {episodeguide} (probably URL).')
         show_id = data_service.parse_url_episodeguide(episodeguide)
     if show_id is None and episodeguide.isdigit():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.3.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.3.4:
- Internal changes.
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
