### PR TITLE
[metadata.tvshows.thetvdb.com.v4.python@matrix] 1.1.5

### DIFF
--- a/metadata.tvshows.thetvdb.com.v4.python/addon.xml
+++ b/metadata.tvshows.thetvdb.com.v4.python/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.thetvdb.com.v4.python" name="The TVDB v4"
-       version="1.1.4" provider-name="TVDB Team">
+       version="1.1.5" provider-name="TVDB Team">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
     <import addon="xbmc.python" version="3.0.0" />
@@ -114,13 +114,13 @@
     <description lang="zh_TW">TheTVDB.com是一個電視節目。該網站是一個龐大並可以由任何人修改的開放性資料庫，並包含可以以多國語言顯示的完整的數據資料。所有內容和圖片都是經由用戶提供使用，有一定的標準或質量。數據庫架構和網站是在GPL下的開放性源碼。</description>
     <platform>all</platform>
     <license>GPL-3.0-or-later</license>
-    <reuselanguageinvoker>false</reuselanguageinvoker>
+    <reuselanguageinvoker>true</reuselanguageinvoker>
     <assets>
       <icon>media/icon.png</icon>
       <screenshot>media/screenshot-1.jpg</screenshot>
       <screenshot>media/screenshot-2.jpg</screenshot>
       <screenshot>media/screenshot-3.jpg</screenshot>
     </assets>
-    <news>- 1.1.4: New episode guide format and fix for specials seasons order</news>
+    <news>- 1.1.5: Fix airs after season error and turn on reuselanguageinvoker</news>
   </extension>
 </addon>

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/episodes.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/episodes.py
@@ -100,20 +100,17 @@ def get_episode_details(id, settings, handle):
     }
 
     if ep.get("airsAfterSeason"):
-        details['sortseason'] = ep.get("airsAfterSeason") + 1
-        details['sortepisode'] = 0
+        details['sortseason'] = ep.get("airsAfterSeason")    
+        details['sortepisode'] = 4096
     if ep.get("airsBeforeSeason"):
         details['sortseason'] = ep.get("airsBeforeSeason")
         details['sortepisode'] = 0
     if ep.get("airsBeforeEpisode"):
         details['sortepisode'] = ep.get("airsBeforeEpisode")
-
     if tags:
         details["tag"] = tags
 
-    logger.debug("details in get episode details")
-    logger.debug(details)
-    logger.debug(ep)
+
     liz.setInfo('video', details)
 
     unique_ids = get_unique_ids(ep)

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
@@ -169,7 +169,7 @@ class Url:
     def season_url(self, id, extended=False):
         url = "{}/seasons/{}".format(self.base_url, id)
         if extended:
-            url = "{}/extended".format(url)
+            url = "{}/extended?meta=episodes".format(url)
         return url
 
     def episode_url(self, id, extended=False):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The TVDB v4
  - Add-on ID: metadata.tvshows.thetvdb.com.v4.python
  - Version number: 1.1.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thetvdb/metadata.tvshows.thetvdb.com.v4.python
  
TheTVDB.com is a TV Scraper. The site is a massive open database that can be modified by anybody and contains full meta data for many shows in different languages. All content and images on the site have been contributed by their users for users and have a high standard or quality. The database schema and website are open source under the GPL.

### Description of changes:

- 1.1.5: Fix airs after season error and turn on reuselanguageinvoker

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
