### PR TITLE
[metadata.tvshows.thetvdb.com.v4.python@matrix] 1.1.6

### DIFF
--- a/metadata.tvshows.thetvdb.com.v4.python/addon.xml
+++ b/metadata.tvshows.thetvdb.com.v4.python/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.thetvdb.com.v4.python" name="The TVDB v4"
-       version="1.1.5" provider-name="TVDB Team">
+       version="1.1.6" provider-name="TVDB Team">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
     <import addon="xbmc.python" version="3.0.0" />
@@ -121,6 +121,6 @@
       <screenshot>media/screenshot-2.jpg</screenshot>
       <screenshot>media/screenshot-3.jpg</screenshot>
     </assets>
-    <news>- 1.1.5: Fix airs after season error and turn on reuselanguageinvoker</news>
+    <news>- 1.1.6: Use artworks data for season posters instead of season image</news>
   </extension>
 </addon>

--- a/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
+++ b/metadata.tvshows.thetvdb.com.v4.python/resources/lib/tvdb.py
@@ -16,6 +16,7 @@ class ArtworkType(enum.IntEnum):
     POSTER = 2
     BACKGROUND = 3
     ICON = 5
+    SEASONPOSTER = 7
     CLEARART = 22
     CLEARLOGO = 23
 
@@ -548,12 +549,14 @@ def get_artworks_from_show(show: dict, language: str = 'eng'):
         return 0, score
 
     artworks = show.get("artworks", [{}])
+    seasons = show.get("seasons", [{}])
     banners = []
     posters = []
     fanarts = []
     icons = []
     cleararts = []
     clearlogos = []
+    season_posters = []
     for art in artworks:
         art_type = art.get('type')
         if art_type == ArtworkType.BANNER:
@@ -568,11 +571,15 @@ def get_artworks_from_show(show: dict, language: str = 'eng'):
             cleararts.append(art)
         elif art_type == ArtworkType.CLEARLOGO:
             clearlogos.append(art)
+        elif art_type == ArtworkType.SEASONPOSTER:
+            season_id = art.get("seasonId", -1)
+            season = next((season for season in seasons if season.get("id", -2) == season_id), None)
+            if season:
+                season_posters.append( (art.get("image", ""), season.get("number", 0) ) )
+
     banners.sort(key=sorter, reverse=True)
     posters.sort(key=sorter, reverse=True)
     fanarts.sort(key=sorter, reverse=True)
-    season_posters = [(season.get("image", ""), season.get("number", 0))
-                      for season in show.get("seasons", [])]
     artwork_dict = {
         'banner': banners,
         'poster': posters,


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The TVDB v4
  - Add-on ID: metadata.tvshows.thetvdb.com.v4.python
  - Version number: 1.1.6
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thetvdb/metadata.tvshows.thetvdb.com.v4.python
  
TheTVDB.com is a TV Scraper. The site is a massive open database that can be modified by anybody and contains full meta data for many shows in different languages. All content and images on the site have been contributed by their users for users and have a high standard or quality. The database schema and website are open source under the GPL.

### Description of changes:

- 1.1.6: Use artworks data for season posters instead of season image

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
