### PR TITLE
[metadata.tvmaze@matrix] 1.3.5

### DIFF
--- a/metadata.tvmaze/addon.xml
+++ b/metadata.tvmaze/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvmaze"
   name="TVmaze"
-  version="1.3.4"
+  version="1.3.5"
   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -20,8 +20,7 @@ We provide an API that can be used by anyone or service like Kodi to retrieve TV
     </assets>
     <website>https://www.tvmaze.com</website>
     <source>https://github.com/romanvm/kodi.tvmaze</source>
-    <news>1.3.4:
-- Internal changes.
+    <news>1.3.4: Fix incompatibility with filename tags in Kodi "Omega".
     </news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>

--- a/metadata.tvmaze/libs/cache_service.py
+++ b/metadata.tvmaze/libs/cache_service.py
@@ -16,6 +16,7 @@
 """Cache-related functionality"""
 
 import json
+import logging
 import os
 import time
 from typing import Optional, Text, Dict, Any, Union
@@ -23,14 +24,14 @@ from typing import Optional, Text, Dict, Any, Union
 import xbmcgui
 import xbmcvfs
 
-from .utils import ADDON_ID, logger
+from .utils import ADDON_ID
 
 EPISODES_CACHE_TTL = 60 * 10  # 10 minutes
 
 
 class MemoryCache:
     _instance = None
-    CACHE_KEY = '__tvmaze_scraper__'
+    CACHE_KEY = f'__{ADDON_ID}_cache__'
 
     def __new__(cls):
         if cls._instance is None:
@@ -52,17 +53,17 @@ class MemoryCache:
     def get(self, obj_id: Union[int, str]) -> Optional[Any]:
         cache_json = self._window.getProperty(self.CACHE_KEY)
         if not cache_json:
-            logger.debug('Memory cache empty')
+            logging.debug('Memory cache empty')
             return None
         try:
             cache = json.loads(cache_json)
         except ValueError as exc:
-            logger.debug(f'Memory cache error: {exc}')
+            logging.debug(f'Memory cache error: {exc}')
             return None
         if cache['id'] != obj_id or time.time() - cache['timestamp'] > EPISODES_CACHE_TTL:
-            logger.debug('Memory cache miss')
+            logging.debug('Memory cache miss')
             return None
-        logger.debug('Memory cache hit')
+        logging.debug('Memory cache hit')
         return cache['object']
 
 
@@ -110,8 +111,8 @@ def load_show_info_from_cache(show_id: Union[int, str]) -> Optional[Dict[str, An
         with open(os.path.join(CACHE_DIR, file_name), 'r', encoding='utf-8') as fo:
             cache_json = fo.read()
         show_info = json.loads(cache_json)
-        logger.debug('Show info cache hit')
+        logging.debug('Show info cache hit')
         return show_info
     except (IOError, EOFError, ValueError) as exc:
-        logger.debug(f'Cache error: {type(exc)} {exc}')
+        logging.debug('Cache error: %s %s', type(exc), exc)
         return None

--- a/metadata.tvmaze/libs/data_service.py
+++ b/metadata.tvmaze/libs/data_service.py
@@ -15,6 +15,7 @@
 
 """Functions to process data"""
 import json
+import logging
 import re
 from collections import defaultdict
 from typing import Optional, Dict, List, Any, Sequence, NamedTuple
@@ -26,7 +27,6 @@ except ImportError:
 from xbmcgui import ListItem
 
 from . import tvmaze_api, cache_service as cache
-from .utils import logger
 
 InfoType = Dict[str, Any]  # pylint: disable=invalid-name
 
@@ -47,7 +47,7 @@ CLEAN_PLOT_REPLACEMENTS = (
     ('</i>', '[/I]'),
     ('</p><p>', '[CR]'),
 )
-SUPPORTED_EXTERNAL_IDS = ('tvdb', 'imdb')
+SUPPORTED_EXTERNAL_IDS = ('tvdb', 'thetvdb', 'imdb')
 
 
 class UrlParseResult(NamedTuple):
@@ -116,7 +116,7 @@ def get_episode_info(show_id: str,
             key = f'{episode_id}_{season}_{episode}'
             episode_info = episodes_map[key]
         except KeyError as exc:
-            logger.error(f'Unable to retrieve episode info: {exc}')
+            logging.error('Unable to retrieve episode info: %s', exc)
     if episode_info is None:
         episode_info = tvmaze_api.load_episode_info(episode_id)
     return episode_info
@@ -313,9 +313,9 @@ def parse_url_nfo_contents(nfo: str) -> Optional[UrlParseResult]:
         if show_id_match is not None:
             provider = show_id_match.group(1)
             show_id = show_id_match.group(2)
-            logger.debug(f'Matched show ID {show_id} by regexp "{regexp}"')
+            logging.debug('Matched show ID %s by regexp "%s"', show_id, regexp)
             return UrlParseResult(provider, show_id)
-    logger.debug('Unable to find show ID in an NFO file')
+    logging.debug('Unable to find show ID in an NFO file')
     return None
 
 
@@ -403,7 +403,7 @@ def _filter_by_year(shows: List[InfoType], year: str) -> Optional[InfoType]:
 
 
 def search_show(title: str, year: str) -> Sequence[InfoType]:
-    logger.debug(f'Searching for TV show {title} ({year})')
+    logging.debug(f'Searching for TV show %s (%s)', title, year)
     raw_search_results = tvmaze_api.search_show(title)
     search_results = [res['show'] for res in raw_search_results]
     if len(search_results) > 1 and year:

--- a/metadata.tvmaze/libs/exception_logger.py
+++ b/metadata.tvmaze/libs/exception_logger.py
@@ -1,4 +1,4 @@
-# (c) Roman Miroshnychenko <roman1972@gmail.com> 2020
+# (c) Roman Miroshnychenko <roman1972@gmail.com> 2023
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,16 +13,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Exception logger with extended diagnostic info"""
+
 import inspect
 import sys
 from contextlib import contextmanager
 from platform import uname
 from pprint import pformat
-from typing import List, Dict, Callable, Generator, Any
+from typing import Any, Dict, Callable, Generator, Iterable, Optional
 
 import xbmc
 
-from .utils import logger
+
+def _log_error(message: str) -> None:
+    xbmc.log(message, level=xbmc.LOGERROR)
 
 
 def _format_vars(variables: Dict[str, Any]) -> str:
@@ -37,15 +40,15 @@ def _format_vars(variables: Dict[str, Any]) -> str:
     var_list.sort(key=lambda i: i[0])
     lines = []
     for var, val in var_list:
-        lines.append(f'{var} = {pformat(val, indent=4)}')
+        lines.append(f'{var} = {pformat(val)}')
     return '\n'.join(lines)
 
 
-def _format_code_context(code_context: List[str], lineno: int, index: int) -> str:
+def _format_code_context(frame_info: inspect.FrameInfo) -> str:
     context = ''
-    if code_context is not None:
-        for i, line in enumerate(code_context, lineno - index):
-            if i == lineno:
+    if frame_info.code_context is not None:
+        for i, line in enumerate(frame_info.code_context, frame_info.lineno - frame_info.index):
+            if i == frame_info.lineno:
                 context += f'{str(i).rjust(5)}:>{line}'
             else:
                 context += f'{str(i).rjust(5)}: {line}'
@@ -64,30 +67,16 @@ Local variables:
 """
 
 
-def _format_frame_info(frame_info: tuple) -> str:
+def _format_frame_info(frame_info: inspect.FrameInfo) -> str:
     return FRAME_INFO_TEMPLATE.format(
-        file_path=frame_info[1],
-        lineno=frame_info[2],
-        code_context=_format_code_context(frame_info[4], frame_info[2],
-                                          frame_info[5]),
-        local_vars=_format_vars(frame_info[0].f_locals)
+        file_path=frame_info.filename,
+        lineno=frame_info.lineno,
+        code_context=_format_code_context(frame_info),
+        local_vars=_format_vars(frame_info.frame.f_locals)
     )
 
 
-EXCEPTION_TEMPLATE = """
-*********************************** Unhandled exception detected ***********************************
-####################################################################################################
-                                           Diagnostic info
-----------------------------------------------------------------------------------------------------
-Exception type  : {exc_type}
-Exception value : {exc}
-System info     : {system_info}
-Python version  : {python_version}
-Kodi version    : {kodi_version}
-sys.argv        : {sys_argv}
-----------------------------------------------------------------------------------------------------
-sys.path:
-{sys_path}
+STACK_TRACE_TEMPLATE = """
 ####################################################################################################
                                             Stack Trace
 ====================================================================================================
@@ -96,8 +85,78 @@ sys.path:
 """
 
 
+def _format_stack_trace(frames: Iterable[inspect.FrameInfo]) -> str:
+    stack_trace = ''
+    for frame_info in frames:
+        stack_trace += _format_frame_info(frame_info)
+    return STACK_TRACE_TEMPLATE.format(stack_trace=stack_trace)
+
+
+EXCEPTION_TEMPLATE = """
+####################################################################################################
+                                     Exception Diagnostic Info
+----------------------------------------------------------------------------------------------------
+Exception type    : {exc_type}
+Exception message : {exc}
+System info       : {system_info}
+Python version    : {python_version}
+Kodi version      : {kodi_version}
+sys.argv          : {sys_argv}
+----------------------------------------------------------------------------------------------------
+sys.path:
+{sys_path}
+{stack_trace_info}
+"""
+
+
+def format_trace(frames_to_exclude: int = 1) -> str:
+    """
+    Returns a pretty stack trace with code context and local variables
+
+    Stack trace info includes the following:
+
+    * File path and line number
+    * Code fragment
+    * Local variables
+
+    It allows to inspect execution state at the point of this function call
+
+    :param frames_to_exclude: How many top frames are excluded from the trace
+        to skip unnecessary info. Since each function call creates a stack frame
+        you need to exclude at least this function frame.
+    """
+    frames = inspect.stack(5)[frames_to_exclude:]
+    return _format_stack_trace(reversed(frames))
+
+
+def format_exception(exc_obj: Optional[Exception] = None) -> str:
+    """
+    Returns a pretty exception stack trace with code context and local variables
+
+    :param exc_obj: exception object (optional)
+    :raises ValueError: if no exception is being handled
+    """
+    if exc_obj is None:
+        _, exc_obj, _ = sys.exc_info()
+    if exc_obj is None:
+        raise ValueError('No exception is currently being handled')
+    stack_trace = inspect.getinnerframes(exc_obj.__traceback__, context=5)
+    stack_trace_info = _format_stack_trace(stack_trace)
+    message = EXCEPTION_TEMPLATE.format(
+        exc_type=exc_obj.__class__.__name__,
+        exc=exc_obj,
+        system_info=uname(),
+        python_version=sys.version.replace('\n', ' '),
+        kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
+        sys_argv=pformat(sys.argv),
+        sys_path=pformat(sys.path),
+        stack_trace_info=stack_trace_info
+    )
+    return message
+
+
 @contextmanager
-def log_exception(logger_func: Callable[[str], None] = logger.error) -> Generator[None, None, None]:
+def catch_exception(logger_func: Callable[[str], None] = _log_error) -> Generator[None, None, None]:
     """
     Diagnostic helper context manager
 
@@ -118,7 +177,7 @@ def log_exception(logger_func: Callable[[str], None] = logger.error) -> Generato
 
     Example::
 
-        with debug_exception():
+        with catch_exception():
             # Some risky code
             raise RuntimeError('Fatal error!')
 
@@ -128,18 +187,8 @@ def log_exception(logger_func: Callable[[str], None] = logger.error) -> Generato
     try:
         yield
     except Exception as exc:
-        stack_trace = ''
-        for frame_info in inspect.trace(5):
-            stack_trace += _format_frame_info(frame_info)
-        message = EXCEPTION_TEMPLATE.format(
-            exc_type=exc.__class__.__name__,
-            exc=exc,
-            system_info=uname(),
-            python_version=sys.version.replace('\n', ' '),
-            kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
-            sys_argv=str(sys.argv),
-            sys_path=pformat(sys.path),
-            stack_trace=stack_trace
-        )
-        logger_func(message)
-        raise exc
+        message = format_exception(exc)
+        # pylint: disable=line-too-long
+        logger_func('\n*********************************** Unhandled exception detected ***********************************\n'
+                    + message)
+        raise

--- a/metadata.tvmaze/libs/imdb_rating.py
+++ b/metadata.tvmaze/libs/imdb_rating.py
@@ -14,11 +14,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
+import logging
 import re
 from typing import Dict, Union, Optional
 
 from . import simple_requests as requests
-from .utils import logger
 
 IMDB_TITLE_URL = 'https://www.imdb.com/title/{}/'
 
@@ -36,6 +36,6 @@ def get_imdb_rating(imdb_id: str) -> Optional[Dict[str, Union[int, float]]]:
                 rating = aggregate_rating['ratingValue']
                 votes = aggregate_rating['ratingCount']
                 return {'rating': rating, 'votes': votes}
-    logger.debug(f'Unable to get IMDB rating for ID {imdb_id}. '
-                 f'Status: {response.status_code}, response: {response.text}')
+    logging.debug('Unable to get IMDB rating for ID %s. Status: %s, response: %s',
+                  imdb_id, response.status_code, response.text)
     return None

--- a/metadata.tvmaze/libs/tvmaze_api.py
+++ b/metadata.tvmaze/libs/tvmaze_api.py
@@ -15,13 +15,13 @@
 
 """Functions to interact with TVmaze API"""
 
+import logging
 from pprint import pformat
 from typing import Text, Optional, Union, List, Dict, Any
 
 from . import cache_service as cache
 from . import simple_requests as requests
 from .imdb_rating import get_imdb_rating
-from .utils import logger
 
 InfoType = Dict[str, Any]  # pylint: disable=invalid-name
 
@@ -49,12 +49,12 @@ def _load_info(url: str,
     :return: API response
     :raises requests.exceptions.HTTPError: if any error happens
     """
-    logger.debug(f'Calling URL "{url}" with params {params}')
+    logging.debug('Calling URL "%s" with params %s', url, params)
     response = requests.get(url, params=params, headers=dict(HEADERS))
     if not response.ok:
         response.raise_for_status()
     json_response = response.json()
-    logger.debug(f'TVmaze response:\n{pformat(json_response)}')
+    logging.debug('TVmaze response:\n%s', pformat(json_response))
     return json_response
 
 
@@ -68,7 +68,7 @@ def search_show(title: str) -> List[InfoType]:
     try:
         return _load_info(SEARCH_URL, {'q': title})
     except requests.HTTPError as exc:
-        logger.error(f'TVmaze returned an error: {exc}')
+        logging.error('TVmaze returned an error: %s', exc)
         return []
 
 
@@ -86,7 +86,7 @@ def load_show_info(show_id: str) -> Optional[InfoType]:
         try:
             show_info = _load_info(show_info_url, params)
         except requests.HTTPError as exc:
-            logger.error(f'TVmaze returned an error: {exc}')
+            logging.error('TVmaze returned an error: %s', exc)
             return None
         if isinstance(show_info['_embedded']['images'], list):
             show_info['_embedded']['images'].sort(key=lambda img: img['main'],
@@ -113,7 +113,7 @@ def load_show_info_by_external_id(provider: str, show_id: str) -> Optional[InfoT
     try:
         return _load_info(SEARCH_BY_EXTERNAL_ID_URL, query)
     except requests.HTTPError as exc:
-        logger.error(f'TVmaze returned an error: {exc}')
+        logging.error('TVmaze returned an error: %s', exc)
         return None
 
 
@@ -123,7 +123,7 @@ def _get_alternate_episode_list_id(show_id: str, episode_order: str) -> Optional
     try:
         alternate_lists = _load_info(url)
     except requests.HTTPError as exc:
-        logger.error(f'TVmaze returned an error: {exc}')
+        logging.error('TVmaze returned an error: %s', exc)
     else:
         for episode_list in alternate_lists:
             if episode_list.get(episode_order):
@@ -140,7 +140,7 @@ def load_alternate_episode_list(show_id: str, episode_order: str) -> Optional[Li
         try:
             raw_alternate_episodes = _load_info(url, {'embed': 'episodes'})
         except requests.HTTPError as exc:
-            logger.error(f'TVmaze returned an error: {exc}')
+            logging.error('TVmaze returned an error: %s', exc)
         else:
             alternate_episodes = []
             for episode in raw_alternate_episodes:
@@ -163,7 +163,7 @@ def load_episode_list(show_id: str, episode_order: str) -> Optional[List[InfoTyp
         try:
             episode_list = _load_info(episode_list_url, {'specials': '1'})
         except requests.HTTPError as exc:
-            logger.error(f'TVmaze returned an error: {exc}')
+            logging.error('TVmaze returned an error: %s', exc)
     return episode_list
 
 
@@ -172,5 +172,5 @@ def load_episode_info(episode_id: Union[str, int]) -> Optional[InfoType]:
     try:
         return _load_info(url)
     except requests.HTTPError as exc:
-        logger.error(f'TVmaze returned an error: {exc}')
+        logging.error('TVmaze returned an error: %s', exc)
         return None

--- a/metadata.tvmaze/main.py
+++ b/metadata.tvmaze/main.py
@@ -13,11 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=missing-docstring
+import logging
 import sys
 
 from libs.actions import router
-from libs.exception_logger import log_exception
+from libs.exception_logger import catch_exception
+from libs.utils import initialize_logging
 
 if __name__ == '__main__':
-    with log_exception():
+    initialize_logging()
+    with catch_exception(logger_func=logging.error):
         router(sys.argv[2][1:])


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze
  - Add-on ID: metadata.tvmaze
  - Version number: 1.3.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze
  
TVmaze is a free user driven TV database curated by TV lovers all over the world. You can track your favorite shows from anywhere.
We provide an API that can be used by anyone or service like Kodi to retrieve TV Metadata, show/episode/cast images, and much more.

### Description of changes:

1.3.4: Fix incompatibility with filename tags in Kodi "Omega".
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
