### PR TITLE
[metadata.themoviedb.org.python@nexus] 3.0.1

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="3.0.0"
+       version="3.0.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,7 +11,10 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v3.0.0 (2024-04-17)
+    <news>v3.0.1 (2024-04-22)
+- fix scraper error when tags are disabled
+
+v3.0.0 (2024-04-17)
 - version 3 for Kodi 20 Nexus and above
 
 v2.2.1 (2024-04-12)

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.1 (2024-04-22)
+- fix scraper error when tags are disabled
+
 v3.0.0 (2024-04-17)
 - version 3 for Kodi 20 Nexus and above
 

--- a/metadata.themoviedb.org.python/python/scraper.py
+++ b/metadata.themoviedb.org.python/python/scraper.py
@@ -160,7 +160,8 @@ def set_info(infotag: xbmc.InfoTagVideo, info_dict):
     infotag.setWriters(info_dict['credits'])
     infotag.setDirectors(info_dict['director'])
     infotag.setPremiered(info_dict['premiered'])
-    infotag.setTags(info_dict['tag'])
+    if 'tag' in info_dict:
+        infotag.setTags(info_dict['tag'])
     if 'mpaa' in info_dict:
         infotag.setMpaa(info_dict['mpaa'])
     if 'trailer' in info_dict:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 3.0.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v3.0.1 (2024-04-22)
- fix scraper error when tags are disabled

v3.0.0 (2024-04-17)
- version 3 for Kodi 20 Nexus and above

v2.2.1 (2024-04-12)
- Update YouTube plugin URL for trailers

v2.2.0 (2024-01-10)
- Support IMDB/TMDB IDs in filename for Kodi 21 Omega (uniqueIDs directly from Kodi)

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
