### PR TITLE
[metadata.tvshows.themoviedb.org.python] v1.7.3

### DIFF
--- a/metadata.tvshows.themoviedb.org.python/addon.xml
+++ b/metadata.tvshows.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.themoviedb.org.python"
   name="TMDb TV Shows"
-  version="1.7.2"
+  version="1.7.3"
   provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -10,8 +10,8 @@
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="00:15"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>1.7.2
-fix for inability to scrape IMDB ratings
+    <news>1.7.3
+fix to properly get English videos as fallback
 	</news>
     <platform>all</platform>
     <license>GPL-3.0-or-later</license>

--- a/metadata.tvshows.themoviedb.org.python/changelog.txt
+++ b/metadata.tvshows.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+1.7.3
+fix to properly using English videos as fallback
+
 1.7.2
 fix for inability to scrape IMDB ratings
 

--- a/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
@@ -193,6 +193,7 @@ def load_show_info(show_id, ep_grouping=None, named_seasons=None):
         params = _get_params()
         params['append_to_response'] = 'credits,content_ratings,external_ids,images,videos,keywords'
         params['include_image_language'] = '%s,en,null' % source_settings["LANG_IMAGES"][0:2]
+        params['include_video_language'] = '%s,en,null' % source_settings["LANG_IMAGES"][0:2]
         show_info = api_utils.load_info(
             show_url, params=params, verboselog=source_settings["VERBOSELOG"])
         if show_info is None:


### PR DESCRIPTION
### Description
fix to properly use English videos as fall back
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
