### PR TITLE
[metadata.themoviedb.org.python@nexus] 3.1.3

### DIFF
--- a/metadata.themoviedb.org.python/addon.xml
+++ b/metadata.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="3.1.2"
+       version="3.1.3"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,7 +11,10 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v3.1.2 (2025-10-05)
+    <news>v3.1.3 (2025-10-12)
+- fix missing fanart from TMDB either way
+
+v3.1.2 (2025-10-05)
 - fix missing fanart from TMDB
 
 v3.0.0 (2024-04-17)

--- a/metadata.themoviedb.org.python/changelog.txt
+++ b/metadata.themoviedb.org.python/changelog.txt
@@ -1,3 +1,6 @@
+v3.1.3 (2025-10-12)
+- fix missing fanart from TMDB either way
+
 v3.1.2 (2025-10-05)
 - fix missing fanart from TMDB
 

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/api_utils.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/api_utils.py
@@ -66,8 +66,8 @@ def load_info(url, params=None, default=None, resp_type = 'json'):
         url = url + '?' + urlencode(params)
     if xbmc:
         xbmc.log('Calling URL "{}"'.format(url), xbmc.LOGDEBUG)
-    if HEADERS:
-        xbmc.log(str(HEADERS), xbmc.LOGDEBUG)
+        if HEADERS:
+            xbmc.log(str(HEADERS), xbmc.LOGDEBUG)
     req = Request(url, headers=HEADERS)
     try:
         response = urlopen(req)

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdb.py
@@ -186,39 +186,42 @@ def _parse_artwork(movie, collection, urlbases, language):
     fanart = []
 
     if 'images' in movie:
-        posters = _get_images_with_fallback(movie['images']['posters'], urlbases, language)
-        landscape = _get_images_with_fallback(movie['images']['backdrops'], urlbases, language)
-        logos = _get_images_with_fallback(movie['images']['logos'], urlbases, language)
-        fanart = _get_images(movie['images']['backdrops'], urlbases, 'xx')
+        posters = _build_image_list_with_fallback(movie['images']['posters'], urlbases, language)
+        landscape = _build_image_list_with_fallback(movie['images']['backdrops'], urlbases, language)
+        logos = _build_image_list_with_fallback(movie['images']['logos'], urlbases, language)
+        fanart = _build_fanart_list(movie['images']['backdrops'], urlbases)
 
     setposters = []
     setlandscape = []
     setfanart = []
     if collection and 'images' in collection:
-        setposters = _get_images_with_fallback(collection['images']['posters'], urlbases, language)
-        setlandscape = _get_images_with_fallback(collection['images']['backdrops'], urlbases, language)
-        setfanart = _get_images(collection['images']['backdrops'], urlbases, 'xx')
+        setposters = _build_image_list_with_fallback(collection['images']['posters'], urlbases, language)
+        setlandscape = _build_image_list_with_fallback(collection['images']['backdrops'], urlbases, language)
+        setfanart = _build_fanart_list(collection['images']['backdrops'], urlbases)
 
     return {'poster': posters, 'landscape': landscape, 'fanart': fanart,
         'set.poster': setposters, 'set.landscape': setlandscape, 'set.fanart': setfanart, 'clearlogo': logos}
 
-def _get_images_with_fallback(imagelist, urlbases, language, language_fallback='en'):
-    images = _get_images(imagelist, urlbases, language)
+def _build_image_list_with_fallback(imagelist, urlbases, language, language_fallback='en'):
+    images = _build_image_list(imagelist, urlbases, [language])
 
     # Add backup images
     if language != language_fallback:
-        images.extend(_get_images(imagelist, urlbases, language_fallback))
+        images.extend(_build_image_list(imagelist, urlbases, [language_fallback]))
 
     # Add any images if nothing set so far
     if not images:
-        images = _get_images(imagelist, urlbases)
+        images = _build_image_list(imagelist, urlbases)
 
     return images
 
-def _get_images(imagelist, urlbases, language='_any'):
+def _build_fanart_list(imagelist, urlbases):
+    return _build_image_list(imagelist, urlbases, ['xx', None])
+
+def _build_image_list(imagelist, urlbases, languages=[]):
     result = []
     for img in imagelist:
-        if language != '_any' and img['iso_639_1'] != language:
+        if languages and img['iso_639_1'] not in languages:
             continue
         if img['file_path'].endswith('.svg'):
             continue

--- a/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdbapi.py
+++ b/metadata.themoviedb.org.python/python/lib/tmdbscraper/tmdbapi.py
@@ -20,7 +20,11 @@
 
 import unicodedata
 from . import api_utils
-import xbmc
+try:
+    import xbmc
+except ModuleNotFoundError:
+    # only used for logging HTTP calls, not available nor needed for testing
+    xbmc = None
 try:
     from typing import Optional, Text, Dict, List, Any  # pylint: disable=unused-import
     InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
@@ -41,6 +45,9 @@ MOVIE_URL = BASE_URL.format('movie/{}')
 COLLECTION_URL = BASE_URL.format('collection/{}')
 CONFIG_URL = BASE_URL.format('configuration')
 
+def log(message):
+    if xbmc:
+        xbmc.log(message, xbmc.LOGDEBUG)
 
 def search_movie(query, year=None, language=None, page=None):
     # type: (Text) -> List[InfoType]
@@ -54,7 +61,7 @@ def search_movie(query, year=None, language=None, page=None):
     :return: a list with found movies
     """
     query = unicodedata.normalize('NFC', query)
-    xbmc.log('using title of %s to find movie' % query, xbmc.LOGDEBUG)
+    log('using title of %s to find movie' % query)
     theurl = SEARCH_URL
     params = _set_params(None, language)
     params['query'] = query
@@ -75,7 +82,7 @@ def find_movie_by_external_id(external_id, language=None):
     :param language: the language filter for TMDb (optional)
     :return: the movie or error
     """
-    xbmc.log('using external id of %s to find movie' % external_id, xbmc.LOGDEBUG)
+    log('using external id of %s to find movie' % external_id)
     theurl = FIND_URL.format(external_id)
     params = _set_params(None, language)
     params['external_source'] = 'imdb_id'
@@ -94,7 +101,7 @@ def get_movie(mid, language=None, append_to_response=None):
     :append_to_response: the additional data to get from TMDb (optional)
     :return: the movie or error
     """
-    xbmc.log('using movie id of %s to get movie details' % mid, xbmc.LOGDEBUG)
+    log('using movie id of %s to get movie details' % mid)
     theurl = MOVIE_URL.format(mid)
     api_utils.set_headers(dict(HEADERS))
     return api_utils.load_info(theurl, params=_set_params(append_to_response, language))
@@ -110,7 +117,7 @@ def get_collection(collection_id, language=None, append_to_response=None):
     :append_to_response: the additional data to get from TMDb (optional)
     :return: the movie or error
     """
-    xbmc.log('using collection id of %s to get collection details' % collection_id, xbmc.LOGDEBUG)
+    log('using collection id of %s to get collection details' % collection_id)
     theurl = COLLECTION_URL.format(collection_id)
     api_utils.set_headers(dict(HEADERS))
     return api_utils.load_info(theurl, params=_set_params(append_to_response, language))
@@ -123,7 +130,7 @@ def get_configuration():
 
     :return: configuration details or error
     """
-    xbmc.log('getting configuration details', xbmc.LOGDEBUG)
+    log('getting configuration details')
     api_utils.set_headers(dict(HEADERS))
     return api_utils.load_info(CONFIG_URL, params=TMDB_PARAMS.copy())
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: The Movie Database Python
  - Add-on ID: metadata.themoviedb.org.python
  - Version number: 3.1.3
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/xbmc/metadata.themoviedb.org.python
  
themoviedb.org is a free and open movie database. It's completely user driven by people like you. TMDb is currently used by millions of people every month and with their powerful API, it is also used by many popular media centers like Kodi to retrieve Movie Metadata, Posters and Fanart to enrich the user's experience.

### Description of changes:

v3.1.3 (2025-10-12)
- fix missing fanart from TMDB either way

v3.1.2 (2025-10-05)
- fix missing fanart from TMDB

v3.0.0 (2024-04-17)
- version 3 for Kodi 20 Nexus and above

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
