### PR TITLE
[metadata.tvshows.themoviedb.org.python] v1.7.5

### DIFF
--- a/metadata.tvshows.themoviedb.org.python/addon.xml
+++ b/metadata.tvshows.themoviedb.org.python/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.themoviedb.org.python"
   name="TMDb TV Shows"
-  version="1.7.4"
+  version="1.7.5"
   provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -10,8 +10,9 @@
   <extension point="xbmc.metadata.scraper.tvshows" library="main.py" cachepersistence="00:15"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>1.7.4
-fix for breaking change to TMDB API for fanart
+    <news>1.7.5
+added option to split keyart from posters
+fixed sorting and trimming so that landscape and keyart aren't deleted
 	</news>
     <platform>all</platform>
     <license>GPL-3.0-or-later</license>

--- a/metadata.tvshows.themoviedb.org.python/changelog.txt
+++ b/metadata.tvshows.themoviedb.org.python/changelog.txt
@@ -1,3 +1,7 @@
+1.7.5
+added option to split keyart from posters
+fixed sorting and trimming so that landscape and keyart aren't deleted
+
 1.7.4
 fix for breaking change to TMDB API for fanart
 

--- a/metadata.tvshows.themoviedb.org.python/libs/data_utils.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/data_utils.py
@@ -213,10 +213,7 @@ def set_show_artwork(show_info, list_item):
             fanart_list = []
             for image in image_list:
                 theurl, previewurl = get_image_urls(image)
-                if (image.get('iso_639_1') != None and image.get('iso_639_1').lower() != 'xx') and SOURCE_SETTINGS["CATLANDSCAPE"] and theurl:
-                    vtag.addAvailableArtwork(
-                        theurl, arttype="landscape", preview=previewurl)
-                elif theurl:
+                if theurl:
                     fanart_list.append({'image': theurl})
             if fanart_list:
                 list_item.setAvailableFanart(fanart_list)

--- a/metadata.tvshows.themoviedb.org.python/libs/settings.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/settings.py
@@ -84,6 +84,7 @@ def getSourceSettings():
     settings["KEEPTITLE"] = source_settings.get(
         'keeporiginaltitle', addon.getSettingBool('keeporiginaltitle'))
     settings["CATLANDSCAPE"] = source_settings.get('cat_landscape', True)
+    settings["CATKEYART"] = source_settings.get('cat_keyart', True)
     settings["STUDIOCOUNTRY"] = source_settings.get('studio_country', False)
     settings["ENABTRAILER"] = source_settings.get(
         'enab_trailer', addon.getSettingBool('enab_trailer'))

--- a/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
+++ b/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
@@ -478,9 +478,32 @@ def _sort_image_types(imagelist):
     :param imagelist:
     :return: imagelist
     """
+    source_settings = settings.getSourceSettings()
+    new_imagelist = {}
     for image_type, images in imagelist.items():
-        imagelist[image_type] = _image_sort(images, image_type)
-    return imagelist
+        if image_type == "backdrops":
+            backdrops = []
+            landscape = []
+            for image in images:
+                if (image.get('iso_639_1') is not None and image.get('iso_639_1').lower() != 'xx') and source_settings["CATLANDSCAPE"]:
+                    landscape.append(image)
+                else:
+                    backdrops.append(image)
+            new_imagelist['landscape'] = _image_sort(landscape, 'landscape')
+            new_imagelist['backdrops'] = _image_sort(backdrops, 'backdrops')
+        elif image_type == 'posters':
+            posters = []
+            keyart = []
+            for image in images:
+                if (image.get('iso_639_1') is None or image.get('iso_639_1').lower() == 'xx') and source_settings["CATKEYART"]:
+                    keyart.append(image)
+                else:
+                    posters.append(image)
+            new_imagelist['posters'] = _image_sort(posters, 'posters')
+            new_imagelist['keyart'] = _image_sort(keyart, 'keyart')
+        else:
+            new_imagelist[image_type] = _image_sort(images, image_type)
+    return new_imagelist
 
 
 def _image_sort(images, image_type):

--- a/metadata.tvshows.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
+++ b/metadata.tvshows.themoviedb.org.python/resources/language/resource.language.en_gb/strings.po
@@ -64,7 +64,11 @@ msgctxt "#30009"
 msgid "Use different language for images"
 msgstr ""
 
-# empty strings from 30009 to 30099
+msgctxt "#30010"
+msgid "Categorize posters without text as key art"
+msgstr ""
+
+# empty strings from 30011 to 30099
 
 msgctxt "#30100"
 msgid "Fanart.tv"

--- a/metadata.tvshows.themoviedb.org.python/resources/settings.xml
+++ b/metadata.tvshows.themoviedb.org.python/resources/settings.xml
@@ -230,6 +230,11 @@
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="cat_keyart" type="boolean" label="30010" help="">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
 				<setting id="studio_country" type="boolean" label="30006" help="">
 					<level>0</level>
 					<default>false</default>


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
- added option to split keyart from posters
- fixed sorting and trimming so that landscape and keyart aren't deleted

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scrapers/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
